### PR TITLE
Add DNSMOS Pro

### DIFF
--- a/docs/supported_metrics.md
+++ b/docs/supported_metrics.md
@@ -52,6 +52,9 @@ We include x mark if the metric is auto-installed in versa.
 | 45 | x | Qwen2 Recording Environment - Channel Type | qwen2_channel_type_metric | qwen2_channel_type_metric | [Qwen2 Audio](https://github.com/QwenLM/Qwen2-Audio) | [paper](https://arxiv.org/abs/2407.10759) |
 | 46 | x | Dimensional Emotion | w2v2_dimensional_emotion | w2v2_dimensional_emotion | [w2v2-how-to](https://github.com/audeering/w2v2-how-to) | [paper](https://arxiv.org/pdf/2203.07378) |
 | 47 | x | Uni-VERSA (Versatile Speech Assessment with a Unified Framework) | universa | universa_{sub_metrics} | [Uni-VERSA](https://huggingface.co/collections/espnet/universa-6834e7c0a28225bffb6e2526) | [paper](https://arxiv.org/abs/2505.20741) |
+| 48 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_bvcc | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
+| 49 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_nisqa | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
+| 50 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_vcc2018 | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
 
 
 

--- a/egs/separate_metrics/pseudo_mos.yaml
+++ b/egs/separate_metrics/pseudo_mos.yaml
@@ -4,7 +4,7 @@
 # -- plcmos: PLC-MOS score
 # -- aecmos: AEC-MOS score
 - name: pseudo_mos
-  predictor_types: ["utmos", "dnsmos", "plcmos", "singmos"]
+  predictor_types: ["utmos", "dnsmos", "plcmos", "singmos", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"]
   predictor_args:
     utmos:
       fs: 16000
@@ -13,4 +13,10 @@
     plcmos:
       fs: 16000
     singmos:
+      fs: 16000
+    dnsmos_pro_bvcc:
+      fs: 16000
+    dnsmos_pro_nisqa:
+      fs: 16000
+    dnsmos_pro_vcc2018:
       fs: 16000

--- a/egs/speech.yaml
+++ b/egs/speech.yaml
@@ -42,7 +42,7 @@
 # -- dnsmos: DNS-MOS score
 # -- plcmos: PLC-MOS score
 - name: pseudo_mos
-  predictor_types: ["utmos", "dnsmos", "plcmos", "singmos"]
+  predictor_types: ["utmos", "dnsmos", "plcmos", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"]
   predictor_args:
     utmos:
       fs: 16000

--- a/egs/speech_gpu.yaml
+++ b/egs/speech_gpu.yaml
@@ -10,7 +10,7 @@
 # -- plcmos: PLC-MOS score
 # -- aecmos: AEC-MOS score
 - name: pseudo_mos
-  predictor_types: ["utmos", "dnsmos", "plcmos"]
+  predictor_types: ["utmos", "dnsmos", "plcmos", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"]
   predictor_args:
     utmos:
       fs: 16000

--- a/egs/survey/configs/speech.yaml
+++ b/egs/survey/configs/speech.yaml
@@ -22,7 +22,7 @@
 # -- dnsmos: DNS-MOS score
 # -- plcmos: PLC-MOS score
 - name: pseudo_mos
-  predictor_types: ["utmos", "dnsmos", "plcmos"]
+  predictor_types: ["utmos", "dnsmos", "plcmos", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"]
   predictor_args:
     utmos:
       fs: 16000

--- a/egs/universa_prepare/gpu_subset.yaml
+++ b/egs/universa_prepare/gpu_subset.yaml
@@ -49,7 +49,7 @@
 # -- plcmos: PLC-MOS score
 # -- aecmos: AEC-MOS score
 - name: pseudo_mos
-  predictor_types: ["utmos", "dnsmos", "plcmos", "singmos", "utmosv2"]
+  predictor_types: ["utmos", "dnsmos", "plcmos", "singmos", "utmosv2", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"]
   predictor_args:
     utmos:
       fs: 16000

--- a/egs/universa_prepare/universa_prepare.yaml
+++ b/egs/universa_prepare/universa_prepare.yaml
@@ -97,7 +97,7 @@
 # -- plcmos: PLC-MOS score
 # -- aecmos: AEC-MOS score
 - name: pseudo_mos
-  predictor_types: ["utmos", "dnsmos", "plcmos", "singmos", "utmosv2"]
+  predictor_types: ["utmos", "dnsmos", "plcmos", "singmos", "utmosv2", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"]
   predictor_args:
     utmos:
       fs: 16000

--- a/scripts/show_result.py
+++ b/scripts/show_result.py
@@ -123,6 +123,9 @@ def discover_metrics(info: List[Dict]) -> Dict[str, Any]:
             "noresqa",
             "torch_squim_mos",
             "warpq",
+            "dnsmos_pro_bvcc",
+            "dnsmos_pro_nisqa",
+            "dnsmos_pro_vcc2018",
         ],
         # Speech Enhancement Metrics
         "speech_enhancement": [
@@ -333,7 +336,7 @@ def estimate_metric_quality(metric_name: str, values: List[float]) -> Dict[str, 
         )
     elif any(
         x in metric_lower
-        for x in ["mos", "quality", "nisqa", "utmos", "singmos", "pesq", "stoi"]
+        for x in ["mos", "quality", "nisqa", "utmos", "singmos", "pesq", "stoi", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"]
     ):
         analysis["higher_is_better"] = True
         analysis["interpretation"] = "Higher values indicate better audio quality"

--- a/scripts/show_result.py
+++ b/scripts/show_result.py
@@ -336,7 +336,18 @@ def estimate_metric_quality(metric_name: str, values: List[float]) -> Dict[str, 
         )
     elif any(
         x in metric_lower
-        for x in ["mos", "quality", "nisqa", "utmos", "singmos", "pesq", "stoi", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"]
+        for x in [
+            "mos",
+            "quality",
+            "nisqa",
+            "utmos",
+            "singmos",
+            "pesq",
+            "stoi",
+            "dnsmos_pro_bvcc",
+            "dnsmos_pro_nisqa",
+            "dnsmos_pro_vcc2018",
+        ]
     ):
         analysis["higher_is_better"] = True
         analysis["interpretation"] = "Higher values indicate better audio quality"

--- a/test/test_general.py
+++ b/test/test_general.py
@@ -41,6 +41,9 @@ TEST_INFO = {
     "torch_squim_stoi": 0.6027805209159851,
     "torch_squim_pesq": 1.1683127880096436,
     "torch_squim_si_sdr": -11.109052658081055,
+    "dnsmos_pro_bvcc": 1.1717286109924316,
+    "dnsmos_pro_nisqa": 1.4733699560165405,
+    "dnsmos_pro_vcc2018": 1.930935263633728,
 }
 
 

--- a/test/test_metrics/test_dnsmos_pro.py
+++ b/test/test_metrics/test_dnsmos_pro.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Jiatong Shi
+# Copyright 2025 Jionghao Han
+# Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 import wave
 import numpy as np
 import pytest

--- a/test/test_metrics/test_dnsmos_pro.py
+++ b/test/test_metrics/test_dnsmos_pro.py
@@ -1,0 +1,88 @@
+import wave
+import numpy as np
+import pytest
+
+from versa.utterance_metrics.pseudo_mos import pseudo_mos_setup, pseudo_mos_metric
+
+
+def generate_fixed_wav(
+    filename, duration=1.0, sample_rate=16000, base_freq=150, envelope_func=None
+):
+    t = np.linspace(0, duration, int(sample_rate * duration), endpoint=False)
+    if envelope_func is None:
+        envelope = 0.5 + 0.5 * np.sin(2 * np.pi * 0.5 * t)
+    else:
+        envelope = envelope_func(t)
+    audio = envelope * np.sin(2 * np.pi * base_freq * t)
+    amplitude = np.iinfo(np.int16).max
+    data = (audio * amplitude).astype(np.int16)
+    with wave.open(str(filename), "w") as wf:
+        wf.setnchannels(1)
+        wf.setsampwidth(2)
+        wf.setframerate(sample_rate)
+        wf.writeframes(data.tobytes())
+
+
+def load_wav_as_array(wav_path, sample_rate=16000):
+    with wave.open(str(wav_path), "rb") as wf:
+        frames = wf.getnframes()
+        audio_data = wf.readframes(frames)
+    audio_array = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32)
+    return audio_array / np.iinfo(np.int16).max
+
+
+@pytest.fixture(scope="session")
+def fixed_audio_wav(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("audio_data")
+    audio_file = tmp_dir / "fixed_audio.wav"
+    generate_fixed_wav(audio_file, duration=1.0, sample_rate=16000, base_freq=150)
+    return audio_file
+
+
+@pytest.fixture(scope="session")
+def fixed_audio(fixed_audio_wav):
+    return load_wav_as_array(fixed_audio_wav)
+
+
+# -------------------------------
+# DNSMOS PRO Unit Test
+# -------------------------------
+def test_dnsmos_pro_metric_identical(fixed_audio):
+    """
+    Test that DNSMOS Pro returns valid scores for a known synthetic audio input.
+    """
+    predictor_dict, predictor_fs = pseudo_mos_setup(
+        [
+            "dnsmos_pro_bvcc",
+            "dnsmos_pro_nisqa",
+            "dnsmos_pro_vcc2018",
+        ],
+        predictor_args={},
+    )
+    scores = pseudo_mos_metric(
+        fixed_audio, fs=16000, predictor_dict=predictor_dict, predictor_fs=predictor_fs
+    )
+
+    required_keys = {"dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"}
+    assert required_keys.issubset(
+        scores.keys()
+    ), f"Missing expected DNSMOS keys. Got: {list(scores.keys())}"
+
+    for key in required_keys:
+        assert isinstance(scores[key], float), f"{key} should be a float"
+        assert (
+            1.0 <= scores[key] <= 5.0
+        ), f"{key} score {scores[key]} out of valid MOS range [1, 5]"
+
+    assert scores["dnsmos_pro_bvcc"] == pytest.approx(
+        1.8937609195709229, rel=1e-3, abs=1e-6
+    ), f"Expected dnsmos_pro_bvcc of 1.0 for identical signals, got {scores['dnsmos_pro_bvcc']}"
+
+    assert scores["dnsmos_pro_nisqa"] == pytest.approx(
+        1.7998836040496826, rel=1e-3, abs=1e-6
+    ), f"Expected dnsmos_pro_nisqa of 1.0 for identical signals, got {scores['dnsmos_pro_nisqa']}"
+
+    assert scores["dnsmos_pro_vcc2018"] == pytest.approx(
+        2.113027334213257, rel=1e-3, abs=1e-6
+    ), f"Expected dnsmos_pro_vcc2018 of 1.0 for identical signals, got {scores['dnsmos_pro_vcc2018']}"
+

--- a/test/test_metrics/test_dnsmos_pro.py
+++ b/test/test_metrics/test_dnsmos_pro.py
@@ -85,4 +85,3 @@ def test_dnsmos_pro_metric_identical(fixed_audio):
     assert scores["dnsmos_pro_vcc2018"] == pytest.approx(
         2.113027334213257, rel=1e-3, abs=1e-6
     ), f"Expected dnsmos_pro_vcc2018 of 1.0 for identical signals, got {scores['dnsmos_pro_vcc2018']}"
-

--- a/versa/metrics.py
+++ b/versa/metrics.py
@@ -124,4 +124,7 @@ NUM_METRIC = [
     "clap_score",
     "apa",
     "pysepm_llr",
+    "dnsmos_pro_bvcc",
+    "dnsmos_pro_nisqa",
+    "dnsmos_pro_vcc2018",
 ]

--- a/versa/utterance_metrics/pseudo_mos.py
+++ b/versa/utterance_metrics/pseudo_mos.py
@@ -11,6 +11,9 @@ logger = logging.getLogger(__name__)
 import librosa
 import numpy as np
 import torch
+import requests
+from pathlib import Path
+from typing import Optional
 
 try:
     import utmosv2
@@ -92,6 +95,16 @@ def pseudo_mos_setup(
             ).to(device)
             predictor_dict["singmos"] = singmos
             predictor_fs["singmos"] = 16000
+        elif predictor.startswith("dnsmos_pro_"):
+            variant = predictor[len("dnsmos_pro_"):]
+            url = f"https://github.com/fcumlin/DNSMOSPro/raw/refs/heads/main/runs/{variant.upper()}/model_best.pt"
+            response = requests.get(url)
+            model_path = Path(cache_dir) / f"dnsmos_pro_{variant}.pt"
+            model_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(model_path, "wb") as f:
+                f.write(response.content)
+            predictor_dict[predictor] = torch.jit.load(model_path, map_location=device)
+            predictor_fs[predictor] = 16000
         else:
             raise NotImplementedError("Not supported {}".format(predictor))
 
@@ -200,6 +213,42 @@ def pseudo_mos_metric(pred, fs, predictor_dict, predictor_fs, use_gpu=False):
                 0
             ].item()
             scores.update(singmos=score)
+        elif predictor.startswith("dnsmos_pro_"):
+            if fs != predictor_fs[predictor]:
+                pred_dnsmos_pro = librosa.resample(
+                    pred, orig_sr=fs, target_sr=predictor_fs[predictor]
+                )
+            else:
+                pred_dnsmos_pro = pred
+            def stft(
+                samples: np.ndarray,
+                win_length: int = 320,
+                hop_length: int = 160,
+                n_fft: int = 320,
+                use_log: bool = True,
+                use_magnitude: bool = True,
+                n_mels: Optional[int] = None,
+            ) -> np.ndarray:
+                if use_log and not use_magnitude:
+                    raise ValueError('Log is only available if the magnitude is to be computed.')
+                if n_mels is None:
+                    spec = librosa.stft(y=samples, win_length=win_length, hop_length=hop_length, n_fft=n_fft)
+                else:
+                    spec = librosa.feature.melspectrogram(
+                        y=samples, win_length=win_length, hop_length=hop_length, n_fft=n_fft, n_mels=n_mels
+                    )
+                spec = spec.T
+                if use_magnitude:
+                    spec = np.abs(spec)
+                if use_log:
+                    spec = np.clip(spec, 10 ** (-7), 10 ** 7)
+                    spec = np.log10(spec)
+                return spec
+    
+            spec = torch.FloatTensor(stft(pred_dnsmos_pro))
+            with torch.no_grad():
+                prediction = predictor_dict[predictor](spec[None, None, ...])
+            scores[predictor] = prediction[0, 0].item()
         else:
             raise NotImplementedError("Not supported {}".format(predictor))
 
@@ -210,7 +259,7 @@ if __name__ == "__main__":
     a = np.random.random(16000)
     print(a)
     predictor_dict, predictor_fs = pseudo_mos_setup(
-        ["utmos", "dnsmos", "plcmos", "singmos"],
+        ["utmos", "dnsmos", "plcmos", "singmos", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"],
         predictor_args={
             "dnsmos": {"fs": 16000},
             "plcmos": {"fs": 16000},

--- a/versa/utterance_metrics/pseudo_mos.py
+++ b/versa/utterance_metrics/pseudo_mos.py
@@ -101,9 +101,12 @@ def pseudo_mos_setup(
             if not model_path.exists():
                 url = f"https://github.com/fcumlin/DNSMOSPro/raw/refs/heads/main/runs/{variant.upper()}/model_best.pt"
                 model_path.parent.mkdir(parents=True, exist_ok=True)
+                logger.info(f"Downloading: \"{url}\" to {model_path}")
                 response = requests.get(url)
                 with open(model_path, "wb") as f:
                     f.write(response.content)
+            else:
+                logger.info(f"Using cached model: {model_path}")
             predictor_dict[predictor] = torch.jit.load(model_path, map_location=device)
             predictor_fs[predictor] = 16000
         else:

--- a/versa/utterance_metrics/pseudo_mos.py
+++ b/versa/utterance_metrics/pseudo_mos.py
@@ -97,12 +97,13 @@ def pseudo_mos_setup(
             predictor_fs["singmos"] = 16000
         elif predictor.startswith("dnsmos_pro_"):
             variant = predictor[len("dnsmos_pro_") :]
-            url = f"https://github.com/fcumlin/DNSMOSPro/raw/refs/heads/main/runs/{variant.upper()}/model_best.pt"
-            response = requests.get(url)
             model_path = Path(cache_dir) / f"dnsmos_pro_{variant}.pt"
-            model_path.parent.mkdir(parents=True, exist_ok=True)
-            with open(model_path, "wb") as f:
-                f.write(response.content)
+            if not model_path.exists():
+                url = f"https://github.com/fcumlin/DNSMOSPro/raw/refs/heads/main/runs/{variant.upper()}/model_best.pt"
+                model_path.parent.mkdir(parents=True, exist_ok=True)
+                response = requests.get(url)
+                with open(model_path, "wb") as f:
+                    f.write(response.content)
             predictor_dict[predictor] = torch.jit.load(model_path, map_location=device)
             predictor_fs[predictor] = 16000
         else:

--- a/versa/utterance_metrics/pseudo_mos.py
+++ b/versa/utterance_metrics/pseudo_mos.py
@@ -101,7 +101,7 @@ def pseudo_mos_setup(
             if not model_path.exists():
                 url = f"https://github.com/fcumlin/DNSMOSPro/raw/refs/heads/main/runs/{variant.upper()}/model_best.pt"
                 model_path.parent.mkdir(parents=True, exist_ok=True)
-                logger.info(f"Downloading: \"{url}\" to {model_path}")
+                logger.info(f'Downloading: "{url}" to {model_path}')
                 response = requests.get(url)
                 with open(model_path, "wb") as f:
                     f.write(response.content)

--- a/versa/utterance_metrics/pseudo_mos.py
+++ b/versa/utterance_metrics/pseudo_mos.py
@@ -2,6 +2,7 @@
 
 # Copyright 2023 Takaaki Saeki
 # Copyright 2024 Jiatong Shi
+# Copyright 2025 Jionghao Han
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
 import logging

--- a/versa/utterance_metrics/pseudo_mos.py
+++ b/versa/utterance_metrics/pseudo_mos.py
@@ -96,7 +96,7 @@ def pseudo_mos_setup(
             predictor_dict["singmos"] = singmos
             predictor_fs["singmos"] = 16000
         elif predictor.startswith("dnsmos_pro_"):
-            variant = predictor[len("dnsmos_pro_"):]
+            variant = predictor[len("dnsmos_pro_") :]
             url = f"https://github.com/fcumlin/DNSMOSPro/raw/refs/heads/main/runs/{variant.upper()}/model_best.pt"
             response = requests.get(url)
             model_path = Path(cache_dir) / f"dnsmos_pro_{variant}.pt"
@@ -220,6 +220,7 @@ def pseudo_mos_metric(pred, fs, predictor_dict, predictor_fs, use_gpu=False):
                 )
             else:
                 pred_dnsmos_pro = pred
+
             def stft(
                 samples: np.ndarray,
                 win_length: int = 320,
@@ -230,21 +231,32 @@ def pseudo_mos_metric(pred, fs, predictor_dict, predictor_fs, use_gpu=False):
                 n_mels: Optional[int] = None,
             ) -> np.ndarray:
                 if use_log and not use_magnitude:
-                    raise ValueError('Log is only available if the magnitude is to be computed.')
+                    raise ValueError(
+                        "Log is only available if the magnitude is to be computed."
+                    )
                 if n_mels is None:
-                    spec = librosa.stft(y=samples, win_length=win_length, hop_length=hop_length, n_fft=n_fft)
+                    spec = librosa.stft(
+                        y=samples,
+                        win_length=win_length,
+                        hop_length=hop_length,
+                        n_fft=n_fft,
+                    )
                 else:
                     spec = librosa.feature.melspectrogram(
-                        y=samples, win_length=win_length, hop_length=hop_length, n_fft=n_fft, n_mels=n_mels
+                        y=samples,
+                        win_length=win_length,
+                        hop_length=hop_length,
+                        n_fft=n_fft,
+                        n_mels=n_mels,
                     )
                 spec = spec.T
                 if use_magnitude:
                     spec = np.abs(spec)
                 if use_log:
-                    spec = np.clip(spec, 10 ** (-7), 10 ** 7)
+                    spec = np.clip(spec, 10 ** (-7), 10**7)
                     spec = np.log10(spec)
                 return spec
-    
+
             spec = torch.FloatTensor(stft(pred_dnsmos_pro))
             with torch.no_grad():
                 prediction = predictor_dict[predictor](spec[None, None, ...])
@@ -259,7 +271,15 @@ if __name__ == "__main__":
     a = np.random.random(16000)
     print(a)
     predictor_dict, predictor_fs = pseudo_mos_setup(
-        ["utmos", "dnsmos", "plcmos", "singmos", "dnsmos_pro_bvcc", "dnsmos_pro_nisqa", "dnsmos_pro_vcc2018"],
+        [
+            "utmos",
+            "dnsmos",
+            "plcmos",
+            "singmos",
+            "dnsmos_pro_bvcc",
+            "dnsmos_pro_nisqa",
+            "dnsmos_pro_vcc2018",
+        ],
         predictor_args={
             "dnsmos": {"fs": 16000},
             "plcmos": {"fs": 16000},


### PR DESCRIPTION
Adds `dnsmos_pro_bvcc`, `dnsmos_pro_nisqa`, and `dnsmos_pro_vcc2018` metrics using pretrained models from [DNSMOS Pro](https://github.com/fcumlin/DNSMOSPro/tree/main), based on the BVCC, NISQA, and VCC2018 datasets.