### PR TITLE
[codex] Implement CLAP score metric

### DIFF
--- a/docs/supported_metrics.md
+++ b/docs/supported_metrics.md
@@ -111,7 +111,7 @@ We include x mark if the metric is auto-installed in versa.
 | 9 |   | Emotion2vec similarity (emo2vec) | emo2vec_similarity | emotion_similarity | [emo2vec](https://github.com/ftshijt/emotion2vec/tree/main) | [paper](https://arxiv.org/abs/2312.15185) | 
 | 10 | x | Speaker Embedding Similarity  | speaker | spk_similarity | [espnet](https://github.com/espnet/espnet) | [paper](https://arxiv.org/abs/2401.17230) |
 | 11 |   | NOMAD: Unsupervised Learning of Perceptual Embeddings For Speech Enhancement and Non-Matching Reference Audio Quality Assessment |  nomad | nomad |[Nomad](https://github.com/shimhz/nomad/tree/main) | [paper](https://arxiv.org/abs/2309.16284) |
-| 12 |   | Contrastive Language-Audio Pretraining Score (CLAP Score) | clap_score | clap_score | [fadtk](https://github.com/gudgud96/frechet-audio-distance) | [paper](https://arxiv.org/abs/2301.12661) |
+| 12 |   | Contrastive Language-Audio Pretraining Score (CLAP Score) | clap_score | clap_score | [frechet-audio-distance](https://github.com/gudgud96/frechet-audio-distance) | [paper](https://arxiv.org/abs/2301.12661) |
 | 13 |   | Accompaniment Prompt Adherence (APA) | apa | apa | [Sony-audio-metrics](https://github.com/SonyCSLParis/audio-metrics) | [paper](https://arxiv.org/abs/2404.00775) |
 | 14 |  | Log Likelihood Ratio (LLR) | pysepm | pysepm_llr | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://ecs.utdallas.edu/loizou/speech/obj_paper_jan08.pdf)|
 | 15 | x | Uni-VERSA (Versatile Speech Assessment with a Unified Framework) with Paired Text | universa | universa_{sub_metrics} | [Uni-VERSA](https://huggingface.co/collections/espnet/universa-6834e7c0a28225bffb6e2526) | [paper](https://arxiv.org/abs/2505.20741) |

--- a/egs/separate_metrics/clap_score.yaml
+++ b/egs/separate_metrics/clap_score.yaml
@@ -1,0 +1,8 @@
+# Contrastive Language-Audio Pretraining Score (CLAP Score)
+# --clap_score: cosine similarity between paired text and audio embeddings
+- name: clap_score
+  submodel_name: 630k-audioset
+  cache_dir: versa_cache/clap_score
+  cache_embeddings: false
+  enable_fusion: false
+  batch_size: 10

--- a/test/test_metrics/test_clap_score.py
+++ b/test/test_metrics/test_clap_score.py
@@ -1,0 +1,66 @@
+import numpy as np
+import pytest
+
+from versa.corpus_metrics import clap_score
+
+
+class FakeCLAPScore:
+    sample_rate = 16000
+
+    def get_text_embeddings(self, text_data):
+        return np.array(
+            [[1.0, 0.0] if text == "low tone" else [0.0, 1.0] for text in text_data]
+        )
+
+    def get_audio_embeddings(self, audio_data, sr):
+        return np.array(
+            [[1.0, 0.0] if np.mean(audio) < 0.0 else [0.0, 1.0] for audio in audio_data]
+        )
+
+    def calculate_clap_score(self, text_embds, audio_embds, batch_size):
+        text_norm = text_embds / np.linalg.norm(text_embds, axis=-1, keepdims=True)
+        audio_norm = audio_embds / np.linalg.norm(audio_embds, axis=-1, keepdims=True)
+        return np.mean(np.sum(text_norm * audio_norm, axis=-1)), 0.0
+
+
+def test_clap_score_setup_requires_dependency(monkeypatch):
+    monkeypatch.setattr(clap_score, "CLAPScore", None)
+    with pytest.raises(ModuleNotFoundError, match="frechet_audio_distance"):
+        clap_score.clap_score_setup()
+
+
+def test_clap_score_scoring_matches_text_by_key(tmp_path):
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    first = audio_dir / "b.wav"
+    second = audio_dir / "a.wav"
+
+    import soundfile as sf
+
+    sf.write(first, -np.ones(16000, dtype=np.float32) * 0.1, 16000)
+    sf.write(second, np.ones(16000, dtype=np.float32) * 0.1, 16000)
+
+    clap_info = {
+        "module": FakeCLAPScore(),
+        "cache_dir": str(tmp_path / "cache"),
+        "cache_embeddings": False,
+        "io": "dir",
+    }
+    scores = clap_score.clap_score_scoring(
+        str(audio_dir),
+        clap_info,
+        text_info={"a.wav": "high tone", "b.wav": "low tone"},
+    )
+
+    assert scores["clap_score"] == pytest.approx(1.0)
+
+
+def test_clap_score_scoring_requires_text(tmp_path):
+    clap_info = {
+        "module": FakeCLAPScore(),
+        "cache_dir": str(tmp_path / "cache"),
+        "cache_embeddings": False,
+        "io": "dir",
+    }
+    with pytest.raises(ValueError, match="requires text"):
+        clap_score.clap_score_scoring(str(tmp_path), clap_info, text_info=None)

--- a/test/test_pipeline/test_clap_score_pipeline.py
+++ b/test/test_pipeline/test_clap_score_pipeline.py
@@ -1,0 +1,51 @@
+import numpy as np
+import yaml
+
+from versa.corpus_metrics import clap_score
+from versa.definition import MetricCategory
+from versa.scorer_shared import VersaScorer, audio_loader_setup
+
+
+class FakeCLAPScore:
+    sample_rate = 16000
+
+    def __init__(self, **kwargs):
+        pass
+
+    def get_text_embeddings(self, text_data):
+        return np.ones((len(text_data), 2), dtype=np.float32)
+
+    def get_audio_embeddings(self, audio_data, sr):
+        return np.ones((len(audio_data), 2), dtype=np.float32)
+
+    def calculate_clap_score(self, text_embds, audio_embds, batch_size):
+        return 1.0, 0.0
+
+
+def test_clap_score_pipeline_registration(monkeypatch, tmp_path):
+    import soundfile as sf
+
+    monkeypatch.setattr(clap_score, "CLAPScore", FakeCLAPScore)
+
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+    sf.write(audio_dir / "test.wav", np.ones(16000, dtype=np.float32) * 0.1, 16000)
+
+    with open("egs/separate_metrics/clap_score.yaml", "r", encoding="utf-8") as f:
+        score_config = yaml.full_load(f)
+    score_config[0]["cache_dir"] = str(tmp_path / "cache")
+
+    scorer = VersaScorer()
+    score_modules = scorer.load_metrics(
+        score_config,
+        use_gt=False,
+        use_gt_text=True,
+        use_gpu=False,
+    )
+    score_info = scorer.score_corpus(
+        audio_loader_setup(str(audio_dir), "dir"),
+        score_modules.filter_by_category(MetricCategory.DISTRIBUTIONAL),
+        text_info={"test.wav": "speech audio"},
+    )
+
+    assert score_info["clap_score"] == 1.0

--- a/tools/install_clap_score.sh
+++ b/tools/install_clap_score.sh
@@ -1,0 +1,3 @@
+#/bin/bash
+
+pip install frechet-audio-distance

--- a/versa/__init__.py
+++ b/versa/__init__.py
@@ -91,6 +91,11 @@ _optional_metric_import(
     "versa.corpus_metrics.espnet_wer",
     ("EspnetWerMetric", "register_espnet_wer_metric"),
 )
+_optional_metric_import(
+    "versa.corpus_metrics.clap_score",
+    ("ClapScoreMetric", "register_clap_score_metric"),
+    "Please install frechet-audio-distance following tools/install_clap_score.sh",
+)
 # from versa.corpus_metrics.fad import FadMetric, register_fad_metric
 _optional_metric_import(
     "versa.corpus_metrics.owsm_wer",

--- a/versa/corpus_metrics/clap_score.py
+++ b/versa/corpus_metrics/clap_score.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Jiatong Shi
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+import logging
+import os
+
+import librosa
+import numpy as np
+
+from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
+from versa.scorer_shared import audio_loader_setup
+from versa.utils_shared import load_audio, wav_normalize
+
+try:
+    from frechet_audio_distance import CLAPScore
+except ImportError:
+    CLAPScore = None
+
+
+def clap_score_setup(
+    submodel_name="630k-audioset",
+    ckpt_dir=None,
+    verbose=False,
+    audio_load_worker=8,
+    enable_fusion=False,
+    cache_dir="versa_cache/clap_score",
+    cache_embeddings=False,
+    io="kaldi",
+):
+    if CLAPScore is None:
+        raise ModuleNotFoundError(
+            "frechet_audio_distance is not installed. "
+            "Please install it with `pip install frechet-audio-distance`."
+        )
+
+    clap = CLAPScore(
+        ckpt_dir=ckpt_dir,
+        submodel_name=submodel_name,
+        verbose=verbose,
+        audio_load_worker=audio_load_worker,
+        enable_fusion=enable_fusion,
+    )
+
+    return {
+        "module": clap,
+        "cache_dir": cache_dir,
+        "cache_embeddings": cache_embeddings,
+        "io": io,
+        "verbose": verbose,
+    }
+
+
+def _load_audio_entry(audio_info):
+    if isinstance(audio_info, tuple):
+        return load_audio(audio_info, "kaldi")
+    return load_audio(audio_info, "soundfile")
+
+
+def _load_audio_list(audio_files, target_sample_rate):
+    audio_data = []
+    for key in sorted(audio_files):
+        sample_rate, wav = _load_audio_entry(audio_files[key])
+        wav = wav_normalize(wav).astype(np.float32)
+        if sample_rate != target_sample_rate:
+            wav = librosa.resample(
+                wav, orig_sr=sample_rate, target_sr=target_sample_rate
+            )
+        audio_data.append(wav.astype(np.float32))
+    return audio_data
+
+
+def clap_score_scoring(
+    pred_x,
+    clap_info,
+    text_info=None,
+    key_info="clap_score",
+    batch_size=10,
+):
+    if text_info is None:
+        raise ValueError("CLAP score requires text references via --text.")
+
+    clap = clap_info["module"]
+    if isinstance(pred_x, dict):
+        eval_files = pred_x
+    else:
+        eval_files = audio_loader_setup(pred_x, clap_info["io"])
+    keys = sorted(eval_files)
+    missing_text = [key for key in keys if key not in text_info]
+    if missing_text:
+        raise ValueError(
+            "Missing text references for CLAP score: {}".format(
+                ", ".join(missing_text[:5])
+            )
+        )
+
+    cache_embeddings = clap_info["cache_embeddings"]
+    if cache_embeddings:
+        os.makedirs(clap_info["cache_dir"], exist_ok=True)
+        text_embds_path = os.path.join(clap_info["cache_dir"], "text_embeddings.npy")
+        audio_embds_path = os.path.join(clap_info["cache_dir"], "audio_embeddings.npy")
+    else:
+        text_embds_path = None
+        audio_embds_path = None
+
+    if text_embds_path is not None and os.path.exists(text_embds_path):
+        logging.info("[CLAP score] Loading text embeddings from %s", text_embds_path)
+        text_embds = np.load(text_embds_path)
+    else:
+        text_data = [text_info[key] for key in keys]
+        text_embds = clap.get_text_embeddings(text_data)
+        if text_embds_path is not None:
+            np.save(text_embds_path, text_embds)
+
+    if audio_embds_path is not None and os.path.exists(audio_embds_path):
+        logging.info("[CLAP score] Loading audio embeddings from %s", audio_embds_path)
+        audio_embds = np.load(audio_embds_path)
+    else:
+        audio_data = _load_audio_list(eval_files, clap.sample_rate)
+        audio_embds = clap.get_audio_embeddings(audio_data, sr=clap.sample_rate)
+        if audio_embds_path is not None:
+            np.save(audio_embds_path, audio_embds)
+
+    if len(text_embds) == 0:
+        raise ValueError("CLAP score text embeddings are empty.")
+    if len(audio_embds) == 0:
+        raise ValueError("CLAP score audio embeddings are empty.")
+    if text_embds.shape != audio_embds.shape:
+        raise ValueError(
+            "CLAP score text and audio embeddings have different shapes: "
+            f"{text_embds.shape} vs. {audio_embds.shape}."
+        )
+
+    clap_score_mean, _ = clap.calculate_clap_score(
+        text_embds, audio_embds, batch_size=batch_size
+    )
+    return {key_info: float(clap_score_mean)}
+
+
+class ClapScoreMetric(BaseMetric):
+    """Corpus-level CLAP score for paired text/audio alignment."""
+
+    def _setup(self):
+        self.io = self.config.get("io", "kaldi")
+        self.batch_size = self.config.get("batch_size", 10)
+        self.clap_info = clap_score_setup(
+            submodel_name=self.config.get("submodel_name", "630k-audioset"),
+            ckpt_dir=self.config.get("ckpt_dir", None),
+            verbose=self.config.get("verbose", False),
+            audio_load_worker=self.config.get("audio_load_worker", 8),
+            enable_fusion=self.config.get("enable_fusion", False),
+            cache_dir=self.config.get("cache_dir", "versa_cache/clap_score"),
+            cache_embeddings=self.config.get("cache_embeddings", False),
+            io=self.io,
+        )
+
+    def compute(self, predictions, references=None, metadata=None):
+        metadata = metadata or {}
+        text_info = metadata.get("text_info")
+        if text_info is None:
+            raise ValueError("CLAP score requires text references via --text.")
+
+        scores = clap_score_scoring(
+            predictions,
+            self.clap_info,
+            text_info=text_info,
+            batch_size=self.batch_size,
+        )
+        return scores["clap_score"]
+
+    def get_metadata(self):
+        return _clap_score_metadata()
+
+
+def _clap_score_metadata():
+    return MetricMetadata(
+        name="clap_score",
+        category=MetricCategory.DISTRIBUTIONAL,
+        metric_type=MetricType.FLOAT,
+        requires_reference=False,
+        requires_text=True,
+        gpu_compatible=True,
+        auto_install=False,
+        dependencies=["frechet_audio_distance", "librosa", "numpy"],
+        description="CLAP score for paired text/audio alignment.",
+        paper_reference="https://arxiv.org/abs/2301.12661",
+        implementation_source="https://github.com/gudgud96/frechet-audio-distance",
+    )
+
+
+def register_clap_score_metric(registry):
+    registry.register(
+        ClapScoreMetric,
+        _clap_score_metadata(),
+        aliases=["clap", "clapscore"],
+    )
+
+
+if __name__ == "__main__":
+    clap_info = clap_score_setup()
+    print(
+        clap_score_scoring(
+            "test/test_samples/test2.scp",
+            clap_info,
+            {"test.wav": "speech audio"},
+        )
+    )

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -320,6 +320,13 @@ class VersaScorer:
     ) -> List[Dict[str, Any]]:
         """Score individual utterances."""
 
+        metric_suite = MetricSuite(
+            {
+                name: metric
+                for name, metric in metric_suite.metrics.items()
+                if metric.get_metadata().category != MetricCategory.DISTRIBUTIONAL
+            }
+        )
         processor = ScoreProcessor(metric_suite, output_file)
         score_info = []
         cache_info = []
@@ -401,7 +408,10 @@ class VersaScorer:
                 score_result = metric.compute(
                     predictions=gen_files, references=base_files, metadata=metadata
                 )
-                score_info.update({name: score_result})
+                if isinstance(score_result, dict):
+                    score_info.update(score_result)
+                else:
+                    score_info.update({name: score_result})
 
             except Exception as e:
                 self.logger.error(f"Error computing corpus metric {name}: {e}")


### PR DESCRIPTION
## Summary

Fixes #33.

- Implements the corpus-level `clap_score` metric using `frechet_audio_distance.CLAPScore`.
- Registers `clap_score` with the current metric registry and scorer corpus path.
- Adds a separate metric YAML, install helper, docs source correction, and focused tests with a fake CLAP model to avoid downloads in CI.
- Rebases the branch onto the current `wavlab-speech/versa:main`.

## Validation

- `NUMBA_DISABLE_JIT=1 conda run -n versa-dev python -m pytest test/test_metrics/test_clap_score.py test/test_pipeline/test_clap_score_pipeline.py -q`
- `conda run -n versa-dev python -m black --check versa/corpus_metrics/clap_score.py versa/scorer_shared.py versa/__init__.py test/test_metrics/test_clap_score.py test/test_pipeline/test_clap_score_pipeline.py`
- `conda run -n versa-dev python -m flake8 versa/corpus_metrics/clap_score.py versa/scorer_shared.py versa/__init__.py test/test_metrics/test_clap_score.py test/test_pipeline/test_clap_score_pipeline.py --count --select=E9,F63,F7,F82 --show-source --statistics`
