### PR TITLE
Support resumable scoring

### DIFF
--- a/test/test_pipeline/test_base_metrics_pipeline.py
+++ b/test/test_pipeline/test_base_metrics_pipeline.py
@@ -1,10 +1,18 @@
+import json
+
 import pytest
 import torch
 
 from versa.corpus_metrics.espnet_wer import register_espnet_wer_metric
 from versa.corpus_metrics.owsm_wer import register_owsm_wer_metric
 from versa.corpus_metrics.whisper_wer import register_whisper_wer_metric
-from versa.definition import MetricRegistry
+from versa.definition import (
+    BaseMetric,
+    MetricCategory,
+    MetricMetadata,
+    MetricRegistry,
+    MetricType,
+)
 from versa.scorer_shared import VersaScorer, find_files
 from versa.sequence_metrics.mcd_f0 import register_mcd_f0_metric
 from versa.sequence_metrics.signal_metric import register_signal_metric
@@ -30,6 +38,58 @@ def _sample_files():
     gen_files = find_files("test/test_samples/test2")
     gt_files = find_files("test/test_samples/test1")
     return gen_files, gt_files
+
+
+class CountingMetric(BaseMetric):
+    calls = 0
+
+    def _setup(self):
+        pass
+
+    def compute(self, predictions, references=None, metadata=None):
+        CountingMetric.calls += 1
+        return 1.0
+
+    def get_metadata(self):
+        return MetricMetadata(
+            name="counting",
+            category=MetricCategory.INDEPENDENT,
+            metric_type=MetricType.FLOAT,
+            requires_reference=False,
+            requires_text=False,
+            gpu_compatible=False,
+            auto_install=False,
+            dependencies=[],
+            description="Test metric that counts compute calls.",
+        )
+
+
+def test_score_utterances_resume_skips_completed_keys(tmp_path):
+    gen_files, _ = _sample_files()
+    completed_key = next(iter(gen_files))
+    output_file = tmp_path / "scores.jsonl"
+    output_file.write_text(
+        json.dumps({"key": completed_key, "counting": 3.0}) + "\n",
+        encoding="utf-8",
+    )
+
+    registry = MetricRegistry()
+    registry.register(CountingMetric, CountingMetric().get_metadata())
+    scorer = VersaScorer(registry)
+    metric_suite = scorer.load_metrics([{"name": "counting"}], use_gt=False)
+
+    CountingMetric.calls = 0
+    score_info = scorer.score_utterances(
+        gen_files,
+        metric_suite,
+        output_file=str(output_file),
+        io="soundfile",
+        resume=True,
+    )
+
+    assert score_info[0] == {"key": completed_key, "counting": 3.0}
+    assert CountingMetric.calls == max(len(gen_files) - 1, 0)
+    assert len(score_info) == len(gen_files)
 
 
 def test_stoi_and_signal_pipeline_with_registry():

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -74,6 +74,14 @@ def get_parser() -> argparse.Namespace:
         action="store_true",
         help="Do not match the groundtruth and generated files.",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Resume utterance scoring from an existing output_file by skipping "
+            "keys already present in the JSONL results."
+        ),
+    )
     return parser
 
 
@@ -158,6 +166,7 @@ def main():
             text_info,
             output_file=args.output_file,
             io=args.io,
+            resume=args.resume,
         )
         logging.info("Summary: {}".format(compute_summary(score_info)))
     else:

--- a/versa/bin/scorer_chunk.py
+++ b/versa/bin/scorer_chunk.py
@@ -83,6 +83,14 @@ def get_parser() -> argparse.Namespace:
         action="store_true",
         help="Do not match the groundtruth and generated files.",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help=(
+            "Resume utterance scoring from an existing output_file by skipping "
+            "keys already present in the JSONL results."
+        ),
+    )
 
     # ---------- NEW: chunking options ----------
     parser.add_argument(
@@ -369,6 +377,7 @@ def main():
             text_info,
             output_file=args.output_file,
             io=args.io,
+            resume=args.resume,
         )
         logging.info("Summary: %s", load_summary(score_info))
     else:

--- a/versa/definition.py
+++ b/versa/definition.py
@@ -191,6 +191,9 @@ class MetricSuite:
         self.metrics = metrics
         self.logger = logging.getLogger(self.__class__.__name__)
 
+    def __len__(self) -> int:
+        return len(self.metrics)
+
     def compute_all(
         self, predictions: Any, references: Any = None, metadata: Dict[str, Any] = None
     ) -> Dict[str, Any]:

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -5,6 +5,7 @@
 
 import logging
 import json
+import os
 import kaldiio
 import soundfile as sf
 import yaml
@@ -97,6 +98,7 @@ def list_scoring(
     output_file: Optional[str] = None,
     io: str = "kaldi",
     batch_size: int = 1,
+    resume: bool = False,
 ) -> List[Dict[str, Any]]:
     """Legacy wrapper for scoring a list of utterances."""
     scorer = VersaScorer(_create_populated_registry())
@@ -108,6 +110,7 @@ def list_scoring(
         output_file=output_file,
         io=io,
         batch_size=batch_size,
+        resume=resume,
     )
 
 
@@ -195,16 +198,76 @@ def corpus_scoring(
     return score_info
 
 
+def _load_existing_jsonl_scores(
+    output_file: Optional[str],
+) -> Dict[str, Dict[str, Any]]:
+    """Load previously written utterance scores keyed by utterance id."""
+    if not output_file or not os.path.exists(output_file):
+        return {}
+
+    existing_scores = {}
+    logger = logging.getLogger(__name__)
+    with open(output_file, "r", encoding="utf-8") as f:
+        for line_number, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                score = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Ignoring invalid JSON line %d in resume file %s",
+                    line_number,
+                    output_file,
+                )
+                continue
+
+            key = score.get("key")
+            if key is None:
+                logger.warning(
+                    "Ignoring resume line %d in %s because it has no key",
+                    line_number,
+                    output_file,
+                )
+                continue
+
+            existing_scores[key] = score
+
+    return existing_scores
+
+
+def _ensure_append_starts_on_new_line(output_file: str) -> None:
+    """Make sure resumed JSONL appends cannot merge with a partial final line."""
+    if not os.path.exists(output_file) or os.path.getsize(output_file) == 0:
+        return
+
+    with open(output_file, "rb") as f:
+        f.seek(-1, os.SEEK_END)
+        if f.read(1) == b"\n":
+            return
+
+    with open(output_file, "a", encoding="utf-8") as f:
+        f.write("\n")
+
+
 class ScoreProcessor:
     """Handles batch processing and caching of scores."""
 
-    def __init__(self, metric_suite: MetricSuite, output_file: Optional[str] = None):
+    def __init__(
+        self,
+        metric_suite: MetricSuite,
+        output_file: Optional[str] = None,
+        resume: bool = False,
+    ):
         self.metric_suite = metric_suite
         self.output_file = output_file
         self.logger = logging.getLogger(self.__class__.__name__)
 
         if output_file:
-            self.file_handle = open(output_file, "w", encoding="utf-8")
+            mode = "a" if resume else "w"
+            if resume:
+                _ensure_append_starts_on_new_line(output_file)
+            self.file_handle = open(output_file, mode, encoding="utf-8")
         else:
             self.file_handle = None
 
@@ -246,6 +309,7 @@ class ScoreProcessor:
                     utt_score, default=default_numpy_serializer
                 )
                 self.file_handle.write(f"{printable_result}\n")
+                self.file_handle.flush()
 
         return batch_score_info
 
@@ -317,6 +381,7 @@ class VersaScorer:
         output_file: Optional[str] = None,
         io: str = "kaldi",
         batch_size: int = 1,
+        resume: bool = False,
     ) -> List[Dict[str, Any]]:
         """Score individual utterances."""
 
@@ -327,12 +392,31 @@ class VersaScorer:
                 if metric.get_metadata().category != MetricCategory.DISTRIBUTIONAL
             }
         )
-        processor = ScoreProcessor(metric_suite, output_file)
-        score_info = []
+        existing_scores = _load_existing_jsonl_scores(output_file) if resume else {}
+        completed_keys = set(existing_scores).intersection(gen_files)
+        if resume and output_file:
+            self.logger.info(
+                "Resume enabled: found %d completed utterances in %s",
+                len(completed_keys),
+                output_file,
+            )
+        elif resume:
+            self.logger.warning(
+                "Resume requested without output_file; scoring normally"
+            )
+
+        processor = ScoreProcessor(metric_suite, output_file, resume=resume)
+        score_info = [
+            existing_scores[key] for key in gen_files if key in existing_scores
+        ]
         cache_info = []
 
         try:
             for key in tqdm(gen_files.keys()):
+                if key in completed_keys:
+                    self.logger.debug("Skipping completed utterance %s", key)
+                    continue
+
                 # Step1: Load and validate generated audio
                 gen_sr, gen_wav = load_audio(gen_files[key], io)
                 gen_wav = wav_normalize(gen_wav)


### PR DESCRIPTION
## Summary

Adds resume support for utterance-level scoring so interrupted runs can continue from an existing JSONL output file instead of starting over.

## Details

- Adds a `--resume` flag to the standard and chunked scorer entrypoints.
- Loads completed utterance keys from an existing output file and skips them during scoring.
- Appends new results safely, including when the existing file is missing a trailing newline.
- Keeps resumed rows in the returned score list so summary computation includes previous and new results.
- Adds `MetricSuite.__len__` so legacy chunked scoring code can safely check loaded metric counts.
- Adds a focused regression test for skipping completed keys.

## Validation

- `conda run -n versa-dev black --check test/test_pipeline/test_base_metrics_pipeline.py versa/bin/scorer.py versa/bin/scorer_chunk.py versa/definition.py versa/scorer_shared.py`
- `conda run -n versa-dev flake8 versa scripts test *.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `conda run -n versa-dev python -m pytest test/test_pipeline/test_base_metrics_pipeline.py::test_score_utterances_resume_skips_completed_keys test/test_pipeline/test_base_metrics_pipeline.py::test_stoi_and_signal_pipeline_with_registry -q`
- `conda run -n versa-dev python -m versa.bin.scorer --pred test/test_samples/test2.scp --gt test/test_samples/test1.scp --score_config egs/separate_metrics/snr_related.yaml --output_file /private/tmp/versa-upstream-resume-cli.jsonl --io soundfile --resume` twice; output stayed at 1 row
- `conda run -n versa-dev python -m versa.bin.scorer_chunk --pred test/test_samples/test2.scp --gt test/test_samples/test1.scp --score_config egs/separate_metrics/snr_related.yaml --output_file /private/tmp/versa-upstream-resume-chunk.jsonl --io soundfile --enable_chunking --chunk_duration 0.5 --hop_duration 0.5 --resume` twice; output stayed at 2 rows
- `python3 -m py_compile versa/definition.py versa/scorer_shared.py versa/bin/scorer.py versa/bin/scorer_chunk.py test/test_pipeline/test_base_metrics_pipeline.py`
- `git diff --check`
