### PR TITLE
Add metric-oriented scoring mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,25 @@ python versa/bin/scorer.py \
     --output_file test_result \
     --io soundfile \
     --resume
+
+# Load and score one metric at a time to reduce peak GPU memory
+python versa/bin/scorer.py \
+    --score_config egs/speech_gpu.yaml \
+    --gt test/test_samples/test1.scp \
+    --pred test/test_samples/test2.scp \
+    --output_file test_result \
+    --io soundfile \
+    --use_gpu True \
+    --scoring_mode metric
 ```
 
 `--resume` reads existing JSONL rows from `--output_file`, skips utterance keys
 that have already been scored, and appends only new results. This is useful for
 long-running evaluations that are interrupted or restarted.
+
+`--scoring_mode metric` loads and runs one metric at a time, then releases
+metric resources before moving to the next metric. This can reduce peak GPU
+memory when many model-backed metrics are configured together.
 
 ### Distributed Evaluation with Slurm
 

--- a/test/test_pipeline/test_base_metrics_pipeline.py
+++ b/test/test_pipeline/test_base_metrics_pipeline.py
@@ -64,6 +64,30 @@ class CountingMetric(BaseMetric):
         )
 
 
+class CountingDictMetric(BaseMetric):
+    calls = 0
+
+    def _setup(self):
+        pass
+
+    def compute(self, predictions, references=None, metadata=None):
+        CountingDictMetric.calls += 1
+        return {"counting_dict": 2.0}
+
+    def get_metadata(self):
+        return MetricMetadata(
+            name="counting_dict",
+            category=MetricCategory.INDEPENDENT,
+            metric_type=MetricType.DICT,
+            requires_reference=False,
+            requires_text=False,
+            gpu_compatible=False,
+            auto_install=False,
+            dependencies=[],
+            description="Test metric returning multiple named scores.",
+        )
+
+
 def test_score_utterances_resume_skips_completed_keys(tmp_path):
     gen_files, _ = _sample_files()
     completed_key = next(iter(gen_files))
@@ -90,6 +114,37 @@ def test_score_utterances_resume_skips_completed_keys(tmp_path):
     assert score_info[0] == {"key": completed_key, "counting": 3.0}
     assert CountingMetric.calls == max(len(gen_files) - 1, 0)
     assert len(score_info) == len(gen_files)
+
+
+def test_score_utterances_by_metric_merges_scores_and_writes_jsonl(tmp_path):
+    gen_files, _ = _sample_files()
+    output_file = tmp_path / "scores.jsonl"
+
+    registry = MetricRegistry()
+    registry.register(CountingMetric, CountingMetric().get_metadata())
+    registry.register(CountingDictMetric, CountingDictMetric().get_metadata())
+    scorer = VersaScorer(registry)
+
+    CountingMetric.calls = 0
+    CountingDictMetric.calls = 0
+    score_info = scorer.score_utterances_by_metric(
+        gen_files,
+        [{"name": "counting"}, {"name": "counting_dict"}],
+        output_file=str(output_file),
+        io="soundfile",
+    )
+
+    assert len(score_info) == len(gen_files)
+    assert CountingMetric.calls == len(gen_files)
+    assert CountingDictMetric.calls == len(gen_files)
+    assert all(score["counting"] == 1.0 for score in score_info)
+    assert all(score["counting_dict"] == 2.0 for score in score_info)
+
+    written_scores = [
+        json.loads(line)
+        for line in output_file.read_text(encoding="utf-8").splitlines()
+    ]
+    assert written_scores == score_info
 
 
 def test_stoi_and_signal_pipeline_with_registry():

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -11,6 +11,7 @@ import logging
 import torch
 import yaml
 
+from versa.definition import MetricCategory
 from versa.scorer_shared import (
     audio_loader_setup,
     VersaScorer,
@@ -82,6 +83,16 @@ def get_parser() -> argparse.Namespace:
             "keys already present in the JSONL results."
         ),
     )
+    parser.add_argument(
+        "--scoring_mode",
+        type=str,
+        default="utterance",
+        choices=["utterance", "metric"],
+        help=(
+            "Scoring loop order. Use 'metric' to load one metric at a time, "
+            "reducing peak GPU memory when many metrics are configured."
+        ),
+    )
     return parser
 
 
@@ -148,17 +159,54 @@ def main():
 
     # Initialize VersaScorer
     scorer = VersaScorer()
+    score_metadata = {
+        config["name"]: scorer.registry.get_metadata(config["name"])
+        for config in score_config
+    }
+    corpus_score_config = [
+        config
+        for config in score_config
+        if (
+            score_metadata[config["name"]]
+            and score_metadata[config["name"]].category
+            == MetricCategory.DISTRIBUTIONAL
+        )
+    ]
 
-    # Load utterance-level metrics
-    utterance_metrics = scorer.load_metrics(
-        score_config,
-        use_gt=(True if gt_files is not None else False),
-        use_gt_text=(True if text_info is not None else False),
-        use_gpu=args.use_gpu,
-    )
+    if args.scoring_mode == "metric":
+        score_info = scorer.score_utterances_by_metric(
+            gen_files,
+            score_config,
+            gt_files,
+            text_info,
+            output_file=args.output_file,
+            io=args.io,
+            resume=args.resume,
+            use_gpu=args.use_gpu,
+        )
+        logging.info("Summary: {}".format(compute_summary(score_info)))
+        utterance_metric_count = int(
+            any(any(key != "key" for key in score) for score in score_info)
+        )
+    else:
+        # Load utterance-level metrics
+        utterance_metrics = scorer.load_metrics(
+            score_config,
+            use_gt=(True if gt_files is not None else False),
+            use_gt_text=(True if text_info is not None else False),
+            use_gpu=args.use_gpu,
+        )
+
+        utterance_metric_count = len(
+            [
+                metric
+                for metric in utterance_metrics.metrics.values()
+                if metric.get_metadata().category != MetricCategory.DISTRIBUTIONAL
+            ]
+        )
 
     # Perform utterance-level scoring
-    if len(utterance_metrics.metrics) > 0:
+    if args.scoring_mode == "utterance" and len(utterance_metrics.metrics) > 0:
         score_info = scorer.score_utterances(
             gen_files,
             utterance_metrics,
@@ -169,20 +217,18 @@ def main():
             resume=args.resume,
         )
         logging.info("Summary: {}".format(compute_summary(score_info)))
-    else:
+    elif utterance_metric_count == 0:
         logging.info("No utterance-level scoring function is provided.")
 
     # Load corpus-level metrics (distributional metrics)
     corpus_metrics = scorer.load_metrics(
-        score_config,
+        corpus_score_config,
         use_gt=(True if gt_files is not None else False),
         use_gt_text=(True if text_info is not None else False),
         use_gpu=args.use_gpu,
     )
 
     # Filter for corpus-level metrics and perform corpus scoring
-    from versa.definition import MetricCategory
-
     corpus_suite = corpus_metrics.filter_by_category(MetricCategory.DISTRIBUTIONAL)
     if len(corpus_suite.metrics) > 0:
         corpus_score_info = scorer.score_corpus(
@@ -197,7 +243,7 @@ def main():
         logging.info("No corpus-level scoring function is provided.")
 
     # Ensure at least one scoring function is provided
-    if len(utterance_metrics.metrics) == 0 and len(corpus_suite.metrics) == 0:
+    if utterance_metric_count == 0 and len(corpus_suite.metrics) == 0:
         raise ValueError("No scoring function is provided")
 
 

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -168,8 +168,7 @@ def main():
         for config in score_config
         if (
             score_metadata[config["name"]]
-            and score_metadata[config["name"]].category
-            == MetricCategory.DISTRIBUTIONAL
+            and score_metadata[config["name"]].category == MetricCategory.DISTRIBUTIONAL
         )
     ]
 

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -3,8 +3,9 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
-import logging
+import gc
 import json
+import logging
 import os
 import kaldiio
 import soundfile as sf
@@ -250,6 +251,34 @@ def _ensure_append_starts_on_new_line(output_file: str) -> None:
         f.write("\n")
 
 
+def _write_jsonl_scores(
+    output_file: Optional[str],
+    score_info: List[Dict[str, Any]],
+) -> None:
+    """Write utterance scores as JSONL in the current utterance order."""
+    if not output_file:
+        return
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        for utt_score in score_info:
+            printable_result = json.dumps(
+                utt_score, default=default_numpy_serializer
+            )
+            f.write(f"{printable_result}\n")
+
+
+def _release_metric_resources() -> None:
+    """Best-effort cleanup after unloading model-backed metrics."""
+    gc.collect()
+    try:
+        import torch
+    except ImportError:
+        return
+
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+
 class ScoreProcessor:
     """Handles batch processing and caching of scores."""
 
@@ -466,6 +495,87 @@ class VersaScorer:
             processor.close()
 
         self.logger.info(f"Scoring completed. Results saved to {output_file}")
+        return score_info
+
+    def score_utterances_by_metric(
+        self,
+        gen_files: Dict[str, str],
+        score_config: List[Dict[str, Any]],
+        gt_files: Optional[Dict[str, str]] = None,
+        text_info: Optional[Dict[str, str]] = None,
+        output_file: Optional[str] = None,
+        io: str = "kaldi",
+        batch_size: int = 1,
+        resume: bool = False,
+        use_gpu: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Score all utterances one metric at a time to lower peak model memory."""
+
+        use_gt = gt_files is not None
+        use_gt_text = text_info is not None
+        existing_scores = _load_existing_jsonl_scores(output_file) if resume else {}
+        score_by_key = {
+            key: dict(existing_scores.get(key, {"key": key})) for key in gen_files
+        }
+
+        for config in score_config:
+            metric_name = config["name"]
+            metadata = self.registry.get_metadata(metric_name)
+            if metadata and metadata.category == MetricCategory.DISTRIBUTIONAL:
+                self.logger.info("Skipping %s for utterance-level scoring", metric_name)
+                continue
+
+            metric_suite = self.load_metrics(
+                [config],
+                use_gt=use_gt,
+                use_gt_text=use_gt_text,
+                use_gpu=use_gpu,
+            )
+            metric_suite = MetricSuite(
+                {
+                    name: metric
+                    for name, metric in metric_suite.metrics.items()
+                    if metric.get_metadata().category != MetricCategory.DISTRIBUTIONAL
+                }
+            )
+
+            if len(metric_suite.metrics) == 0:
+                self.logger.info(
+                    "Skipping %s for utterance-level scoring", metric_name
+                )
+                _release_metric_resources()
+                continue
+
+            try:
+                self.logger.info("Scoring utterances with metric %s", metric_name)
+                metric_scores = self.score_utterances(
+                    gen_files,
+                    metric_suite,
+                    gt_files=gt_files,
+                    text_info=text_info,
+                    output_file=None,
+                    io=io,
+                    batch_size=batch_size,
+                    resume=False,
+                )
+                for utt_score in metric_scores:
+                    key = utt_score.get("key")
+                    if key is None:
+                        continue
+                    score_by_key.setdefault(key, {"key": key}).update(utt_score)
+            finally:
+                del metric_suite
+                _release_metric_resources()
+
+            _write_jsonl_scores(
+                output_file,
+                [score_by_key[key] for key in gen_files if key in score_by_key],
+            )
+
+        score_info = [score_by_key[key] for key in gen_files if key in score_by_key]
+        self.logger.info(
+            f"Metric-oriented scoring completed. Results saved to {output_file}"
+        )
         return score_info
 
     def score_corpus(

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -261,9 +261,7 @@ def _write_jsonl_scores(
 
     with open(output_file, "w", encoding="utf-8") as f:
         for utt_score in score_info:
-            printable_result = json.dumps(
-                utt_score, default=default_numpy_serializer
-            )
+            printable_result = json.dumps(utt_score, default=default_numpy_serializer)
             f.write(f"{printable_result}\n")
 
 
@@ -540,9 +538,7 @@ class VersaScorer:
             )
 
             if len(metric_suite.metrics) == 0:
-                self.logger.info(
-                    "Skipping %s for utterance-level scoring", metric_name
-                )
+                self.logger.info("Skipping %s for utterance-level scoring", metric_name)
                 _release_metric_resources()
                 continue
 


### PR DESCRIPTION
## Summary

Adds an opt-in metric-oriented scoring mode for utterance-level evaluation. In this mode, VERSA loads one configured metric, scores all utterances, writes merged JSONL results, then releases Python and CUDA cache before moving to the next metric.

## Why

Fixes the CUDA out-of-memory issue reported in #45 when many model-backed metrics are configured together. The existing utterance-oriented path eagerly loads all metric models before scoring, so peak GPU memory grows with the number of metrics.

## Changes

- Add `--scoring_mode {utterance,metric}` to `versa/bin/scorer.py`
- Add `VersaScorer.score_utterances_by_metric()`
- Preserve default utterance-oriented behavior
- Document metric-oriented scoring in the README
- Add a focused pipeline test for merged JSONL output

## Validation

- `black --check versa/bin/scorer.py versa/scorer_shared.py test/test_pipeline/test_base_metrics_pipeline.py`
- `python3 -m py_compile versa/scorer_shared.py versa/bin/scorer.py test/test_pipeline/test_base_metrics_pipeline.py`
- `git diff --check`
