### PR TITLE
Fix speaker metric import side effects

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ VERSA aligns with original APIs provided by algorithm developers rather than red
 
 For metrics marked without "x" in the "Auto-Install" column of our metrics tables, please use the installers provided in the `tools` directory.
 
+### Installation Notes
+
+Some optional metric backends emit warnings during setup or first use. ESPnet may
+print a `flash_attn` warning when Flash Attention is not available; VERSA can
+still run metrics that do not require that backend. FADTK is only needed for
+FAD/KID-style metrics and can be installed with `tools/install_fadtk.sh` when
+those metrics are selected.
+
+If NLTK downloads fail with a certificate verification error, point Python at
+the certificate bundle used by `certifi` before running the tests:
+
+```bash
+export SSL_CERT_FILE=$(python -c "import certifi; print(certifi.where())")
+```
+
 
 ## 🧪 Quick Testing
 


### PR DESCRIPTION
Fixes part of #59 by avoiding heavy ESPnet speaker imports during import versa / speaker metric registration.

Summary:
- Lazily import espnet2.bin.spk_inference.Speech2Embedding inside speaker_model_setup instead of at module import time.
- Keep the missing-ESPnet error at metric setup time.
- Add a regression test that speaker registration does not import ESPnet.
- Document installation notes for Flash Attention warnings, FADTK-only metrics, and NLTK certificate failures.

Validation:
- python3 -m py_compile versa/utterance_metrics/speaker.py test/test_metrics/test_base_metrics.py
- Stubbed local verification that register_speaker_metric does not import ESPnet and SpeakerMetric still raises the expected missing dependency error.
