### PR TITLE
[codex] Move fastdtw to audio extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ jupyter = [
 audio = [
     "audioread",
     "ci-sdr",
+    "fastdtw",
     "fast-bss-eval",
     "librosa",
     "mir-eval",
@@ -107,7 +108,6 @@ external = [
     "espnet @ git+https://github.com/ftshijt/espnet.git@espnet_inference",
     "espnet-tts-frontend",
     "espnet_model_zoo",
-    "fastdtw",
     "kaggle",
     "openai-whisper @ git+https://github.com/openai/whisper.git",
     "s3prl",


### PR DESCRIPTION
## Summary
- move `fastdtw` from the `external` extra to the `audio` extra
- keep heavier integrations such as the ESPnet fork, Whisper, and `s3prl` under `external`

## Motivation
The ESPnet MFA dependency discussion needs a lighter Versa extra that covers audio/evaluation metric dependencies without pulling in incompatible external integrations. `mcd_f0` depends on `fastdtw` alongside audio packages such as `pysptk` and `pyworld`, so `fastdtw` belongs with the `audio` extra.

## Validation
- `git diff --cached --check`
- `python3 -m py_compile versa/sequence_metrics/mcd_f0.py`
- parsed `pyproject.toml` with `tomllib` and confirmed `fastdtw` is in `audio` and not `external`

## Follow-up checked locally
- Installed local `scoreq_versa` into `.codex-test-venv` from the existing `scoreq/` checkout
- Ran `VERSA_RUN_REAL_MODEL_TESTS=1 VERSA_HF_CACHE_DIR=$PWD/versa_cache/huggingface VERSA_DISCRETE_SPEECH_CACHE_DIR=$PWD/versa_cache/discrete_speech_metrics .codex-test-venv/bin/python -m pytest test/test_pipeline/test_scoreq.py -q -s` and confirmed `1 passed`
- Found local installer-script robustness edits for `tools/install_scoreq.sh` and `tools/install_fairseq.sh`; these are not part of this PR yet unless committed and pushed separately
