### PR TITLE
Add registry-backed distributional metrics tests

### DIFF
--- a/docs/metric_migration.md
+++ b/docs/metric_migration.md
@@ -91,10 +91,7 @@ be updated as each metric is migrated.
 
 ### Corpus and Distributional Metrics
 
-- `versa/corpus_metrics/fad.py`
 - `versa/corpus_metrics/individual_fad.py`
-- `versa/corpus_metrics/kid.py`
-- `versa/corpus_metrics/clap_score.py`
 
 ### Already Migrated Examples
 
@@ -103,7 +100,10 @@ Use these as local references when migrating the remaining metrics:
 - `versa/sequence_metrics/mcd_f0.py`
 - `versa/sequence_metrics/signal_metric.py`
 - `versa/sequence_metrics/warpq.py`
+- `versa/corpus_metrics/clap_score.py`
 - `versa/corpus_metrics/espnet_wer.py`
+- `versa/corpus_metrics/fad.py`
+- `versa/corpus_metrics/kid.py`
 - `versa/corpus_metrics/owsm_wer.py`
 - `versa/corpus_metrics/whisper_wer.py`
 - `versa/utterance_metrics/log_wmse.py`

--- a/docs/metric_review_plan.md
+++ b/docs/metric_review_plan.md
@@ -1,0 +1,77 @@
+# Existing Metrics Review Plan
+
+This review uses `docs/contributing.md` as the checklist for existing metrics:
+object-oriented implementation, registry exposure, metadata, optional dependency
+handling, docs/examples, and focused tests. User-facing YAML names and report
+keys should remain backward compatible unless a future migration explicitly
+documents a breaking change.
+
+## Ready / Keep
+
+These metrics already follow the current `BaseMetric` and registry shape well
+enough for normal maintenance. Future changes should stay limited to bug fixes,
+metadata corrections, and real-model validation.
+
+| Bucket | Metrics | Next move |
+| --- | --- | --- |
+| Sequence/dependent wrappers | `mcd_f0`, `signal_metric`, `warpq`, `stoi`, `pesq`, `log_wmse`, `pysepm`, `asr_match`, `chroma_alignment`, `dpam`, `cdpam` | Keep output keys and YAML aliases stable; add focused tests only when behavior changes. |
+| Independent utterance metrics | `pseudo_mos`, `se_snr`, `sheet_ssqa`, `speaking_rate`, `squim_no_ref`, `srmr`, `vad`, `vqscore`, `wvmos`, `nisqa`, `pam`, `sigmos`, `audiobox_aesthetics`, `asvspoof`, `emo_vad` | Keep optional imports guarded and verify base package import remains safe. |
+| ASR/text-assisted metrics | `espnet_wer`, `owsm_wer`, `whisper_wer`, `fwhisper_wer`, `nemo_wer`, `hubert_wer`, `owsm_lid` | Recheck `requires_text`, aliases, and installer notes whenever backend defaults change. |
+| Multi-metric model families | `qwen2_audio`, `qwen_omni`, `scoreq`, `universa`, `arecho` | Keep generated registry names, aliases, and report keys synchronized with examples and docs. |
+
+## Registry / Export Fix
+
+These items were reviewed because the implementation existed but default
+registry discovery was incomplete.
+
+| Metric | Finding | Status |
+| --- | --- | --- |
+| `asvspoof` / `asvspoof_score` | `register_asvspoof_metric` existed but was not exposed from `versa/__init__.py`. | Fixed by adding `_optional_metric_import(...)`; covered by registry discovery test. |
+| `emo_vad` | `register_emo_vad_metric` existed but was not exposed from `versa/__init__.py`. | Fixed by adding `_optional_metric_import(...)`; covered by registry discovery test. |
+| `fad` | Legacy corpus helper was not registered in the default metric registry. | Fixed by adding `FadMetric`, `register_fad_metric`, and `versa/__init__.py` export. |
+| `kid` | Legacy corpus helper was not registered in the default metric registry. | Fixed by adding `KidMetric`, `register_kid_metric`, and `versa/__init__.py` export. |
+
+## Metadata / Documentation Fix
+
+These items need metadata or docs attention separate from implementation shape.
+
+| Metric | Requirement | Status |
+| --- | --- | --- |
+| `nomad` | Non-matching reference metric should use `MetricCategory.NON_MATCH` while still requiring reference audio. | Fixed in metadata and tests. |
+| `noresqa_score`, `noresqa_mos` | Non-matching reference metrics should use `MetricCategory.NON_MATCH` while still requiring reference audio. | Fixed in metadata and tests. |
+| `emo2vec_similarity` / `emotion` | Similarity uses reference audio that need not be matched; category should be `NON_MATCH`. | Fixed in metadata and tests. |
+| `qwen_omni_*` | Code/tests existed but `docs/supported_metrics.md` and `egs/separate_metrics` lacked a dedicated entry/example. | Fixed with grouped docs row and `egs/separate_metrics/qwen_omni.yaml`. |
+| `kid` | Distributional docs row had malformed table columns. | Fixed in `docs/supported_metrics.md`. |
+| Auto-install marks | Several metrics rely on optional groups, model downloads, or external installers. | Still requires periodic review against `pyproject.toml` and installer scripts before releases. |
+
+## Migration Required
+
+| Metric | Required migration work | Status |
+| --- | --- | --- |
+| `fad` | Add `BaseMetric`, `MetricMetadata`, registry integration, distributional scorer compatibility, and tests while preserving `fad_overall` and `fad_r2`. | Implemented through `FadMetric`; legacy setup/scoring helpers were removed. |
+| `kid` | Add `BaseMetric`, `MetricMetadata`, registry integration, distributional scorer compatibility, guarded FADTK import, and tests while preserving KID output keys. | Implemented through `KidMetric`; legacy setup/scoring helpers were removed. |
+| `individual_fad` | Empty placeholder module with no implementation, metadata, docs, example, or tests. | Leave unregistered; decide in a future issue whether to remove it or implement a real metric. |
+
+## Needs Real-Model Verification
+
+Lightweight tests use mocks for model-heavy metrics. Before a release, run
+real-model checks only in environments with the matching dependencies,
+checkpoints, and licenses.
+
+| Metric family | Verification needed |
+| --- | --- |
+| Distributional audio metrics | Run real FAD/KID/CLAP scoring after `tools/install_fadtk.sh` or `tools/install_clap_score.sh`. |
+| External speech quality models | Run `scoreq`, `nomad`, `noresqa`, `visqol`, `wvmos`, `srmr`, `pysepm`, `audiobox_aesthetics`, and `asvspoof` with their installer scripts. |
+| Foundation-model profilers | Run `qwen2_audio`, `qwen_omni`, `universa`, and `arecho` in a GPU-capable environment and confirm output keys are stable. |
+| ASR-backed metrics | Run WER/LID metrics with expected model caches and transcript inputs, including missing-text failure cases. |
+
+## Static Audit Checks
+
+Keep these checks as the minimum review checklist for future metric work:
+
+- Every importable metric module has a `BaseMetric` subclass, or is explicitly documented as pending/legacy.
+- Every `register_*_metric` function is exposed through `versa/__init__.py`.
+- Every documented `Key in config` resolves through `MetricRegistry` as a canonical name or alias.
+- Every YAML name in `egs/separate_metrics` resolves through `MetricRegistry`.
+- Optional dependencies do not break `import versa`; missing backends raise clear `ImportError` or `ModuleNotFoundError` from setup.
+- Focused tests cover registration, aliases, metadata, input validation, output keys, and missing optional dependencies.

--- a/docs/supported_metrics.md
+++ b/docs/supported_metrics.md
@@ -50,16 +50,17 @@ We include x mark if the metric is auto-installed in versa.
 | 43 | x | Qwen2 Recording Environment - Background | qwen2_speech_background_environment_metric | qwen2_speech_background_environment_metric | [Qwen2 Audio](https://github.com/QwenLM/Qwen2-Audio) | [paper](https://arxiv.org/abs/2407.10759) |
 | 44 | x | Qwen2 Recording Environment - Quality | qwen2_recording_quality_metric | qwen2_recording_quality_metric | [Qwen2 Audio](https://github.com/QwenLM/Qwen2-Audio) | [paper](https://arxiv.org/abs/2407.10759) |
 | 45 | x | Qwen2 Recording Environment - Channel Type | qwen2_channel_type_metric | qwen2_channel_type_metric | [Qwen2 Audio](https://github.com/QwenLM/Qwen2-Audio) | [paper](https://arxiv.org/abs/2407.10759) |
-| 46 | x | Dimensional Emotion | emo_vad | arousal_emo_vad, valence_emo_vad, dominance_emo_vad | [w2v2-how-to](https://github.com/audeering/w2v2-how-to) | [paper](https://arxiv.org/pdf/2203.07378) |
-| 47 | x | Uni-VERSA (Versatile Speech Assessment with a Unified Framework) | universa, universa_noref, universa_audioref, universa_textref, universa_fullref | universa_{sub_metrics} | [Uni-VERSA](https://huggingface.co/collections/espnet/universa-6834e7c0a28225bffb6e2526) | [paper](https://arxiv.org/abs/2505.20741) |
-| 48 |   | ARECHO (Audio Reference Echo Cancellation and Codec Quality Assessment) - No Reference | arecho, arecho_noref | arecho_{sub_metrics} | [ARECHO](https://huggingface.co/espnet/arecho_base_v0) | [paper](https://arxiv.org/abs/2505.20741) |
-| 49 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_bvcc | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
-| 50 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_nisqa | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
-| 51 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_vcc2018 | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
-| 52 |   | WV-MOS (MOS score prediction by fine-tuned wav2vec2.0 model) | wvmos | wvmos | [wvmos](https://github.com/AndreevP/wvmos) | [paper](https://arxiv.org/abs/2203.13086) |
-| 53 |   |SIG-MOS | sigmos | {SIGMOS_COL, SIGMOS_DISC, SIGMOS_LOUD, SIGMOS_REVERB, SIGMOS_SIG, SIGMOS_OVRL} | [sigmos](https://github.com/microsoft/SIG-Challenge/tree/main/ICASSP2024/sigmos) |[paper](https://arxiv.org/pdf/2309.07385) |
-| 54 | x | VQScore (Self-Supervised Speech Quality Estimation and Enhancement Using Only Clean Speech)  | vqscore | vqscore | [VQScore](https://github.com/JasonSWFu/VQscore) | [paper](https://arxiv.org/abs/2402.16321) |
-| 55 | x | Singing voice MOS  | pseudo_mos | singmos_pro |[singmos](https://github.com/South-Twilight/SingMOS) | [paper](https://arxiv.org/abs/2510.01812) |
+| 46 | x | Qwen2.5-Omni Speech and Singing Characteristics | qwen_omni_{sub_metrics}, qwen_omni_{sub_metrics}_metric | qwen_omni_{sub_metrics} | [Qwen2.5-Omni](https://github.com/QwenLM/Qwen2.5-Omni) | - |
+| 47 | x | Dimensional Emotion | emo_vad | arousal_emo_vad, valence_emo_vad, dominance_emo_vad | [w2v2-how-to](https://github.com/audeering/w2v2-how-to) | [paper](https://arxiv.org/pdf/2203.07378) |
+| 48 | x | Uni-VERSA (Versatile Speech Assessment with a Unified Framework) | universa, universa_noref, universa_audioref, universa_textref, universa_fullref | universa_{sub_metrics} | [Uni-VERSA](https://huggingface.co/collections/espnet/universa-6834e7c0a28225bffb6e2526) | [paper](https://arxiv.org/abs/2505.20741) |
+| 49 |   | ARECHO (Audio Reference Echo Cancellation and Codec Quality Assessment) - No Reference | arecho, arecho_noref | arecho_{sub_metrics} | [ARECHO](https://huggingface.co/espnet/arecho_base_v0) | [paper](https://arxiv.org/abs/2505.20741) |
+| 50 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_bvcc | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
+| 51 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_nisqa | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
+| 52 | x | DNSMOS Pro: A Reduced-Size DNN for Probabilistic MOS of Speech  | pseudo_mos | dnsmos_pro_vcc2018 | [DNSMOSPro](https://github.com/fcumlin/DNSMOSPro/tree/main) | [paper](https://www.isca-archive.org/interspeech_2024/cumlin24_interspeech.html) |
+| 53 |   | WV-MOS (MOS score prediction by fine-tuned wav2vec2.0 model) | wvmos | wvmos | [wvmos](https://github.com/AndreevP/wvmos) | [paper](https://arxiv.org/abs/2203.13086) |
+| 54 |   |SIG-MOS | sigmos | {SIGMOS_COL, SIGMOS_DISC, SIGMOS_LOUD, SIGMOS_REVERB, SIGMOS_SIG, SIGMOS_OVRL} | [sigmos](https://github.com/microsoft/SIG-Challenge/tree/main/ICASSP2024/sigmos) |[paper](https://arxiv.org/pdf/2309.07385) |
+| 55 | x | VQScore (Self-Supervised Speech Quality Estimation and Enhancement Using Only Clean Speech)  | vqscore | vqscore | [VQScore](https://github.com/JasonSWFu/VQscore) | [paper](https://arxiv.org/abs/2402.16321) |
+| 56 | x | Singing voice MOS  | pseudo_mos | singmos_pro |[singmos](https://github.com/South-Twilight/SingMOS) | [paper](https://arxiv.org/abs/2510.01812) |
 
 
 ### Dependent Metrics
@@ -125,7 +126,7 @@ We include x mark if the metric is auto-installed in versa.
 | 2 |   | Kullback-Leibler Divergence on Embedding Distribution | kl_embedding | kl_embedding | [Stability-AI](https://github.com/Stability-AI/stable-audio-metrics) |  |
 | 3 |   | Audio Density Score | audio_density_coverage | audio_density | [Sony-audio-metrics](https://github.com/SonyCSLParis/audio-metrics) | [paper](https://arxiv.org/abs/2002.09797) |
 | 4 |   | Audio Coverage Score | audio_density_coverage | audio_coverage | [Sony-audio-metrics](https://github.com/SonyCSLParis/audio-metrics) | [paper](https://arxiv.org/abs/2002.09797) |
-| 5 |  | KID : Kernel Distance Metric for Audio/Music Quality | [KID](https://github.com/SonyCSLParis/audio-metrics/tree/main) | [Paper](https://arxiv.org/abs/1812.08466)|
+| 5 |  | KID : Kernel Distance Metric for Audio/Music Quality | kid | kid_mean, kid_std | [KID](https://github.com/SonyCSLParis/audio-metrics/tree/main) | [Paper](https://arxiv.org/abs/1812.08466)|
 
 ## Acknowledgement
 We sincerely thank all the open-source implementations listed in https://github.com/shinjiwlab/versa/tree/main#list-of-metrics 

--- a/egs/separate_metrics/qwen_omni.yaml
+++ b/egs/separate_metrics/qwen_omni.yaml
@@ -1,0 +1,54 @@
+# Metrics with Qwen2.5-Omni
+# Inference pipeline follows the Qwen2.5-Omni release:
+# https://github.com/QwenLM/Qwen2.5-Omni
+
+# 1. Speaker Characteristics
+- name: qwen_omni_speaker_count
+
+- name: qwen_omni_speaker_gender
+
+- name: qwen_omni_speaker_age
+
+- name: qwen_omni_speech_impairment
+
+# 2. Voice Properties
+- name: qwen_omni_voice_pitch
+
+- name: qwen_omni_pitch_range
+
+- name: qwen_omni_voice_type
+
+- name: qwen_omni_speech_volume_level
+
+# 3. Speech Content
+- name: qwen_omni_language
+
+- name: qwen_omni_speech_register
+
+- name: qwen_omni_vocabulary_complexity
+
+- name: qwen_omni_speech_purpose
+
+# 4. Speech Delivery
+- name: qwen_omni_speech_emotion
+
+- name: qwen_omni_speech_clarity
+
+- name: qwen_omni_speech_rate
+
+- name: qwen_omni_speaking_style
+
+- name: qwen_omni_laughter_crying
+
+# 5. Interaction Patterns
+- name: qwen_omni_overlapping_speech
+
+# 6. Recording Environment
+- name: qwen_omni_speech_background_environment
+
+- name: qwen_omni_recording_quality
+
+- name: qwen_omni_channel_type
+
+# 7. Singing
+- name: qwen_omni_singing_technique

--- a/test/test_metrics/test_distributional_metrics.py
+++ b/test/test_metrics/test_distributional_metrics.py
@@ -1,0 +1,130 @@
+import pytest
+
+from versa.corpus_metrics import fad as fad_module
+from versa.corpus_metrics import kid as kid_module
+from versa.definition import MetricCategory, MetricRegistry
+from versa.scorer_shared import (
+    VersaScorer,
+    _create_populated_registry,
+    load_score_modules,
+)
+
+
+class DummyFadScore:
+    score = 0.25
+    r2 = 0.75
+
+
+class DummyFadBackend:
+    def __init__(self, ml=None, load_model=True):
+        self.ml = ml
+        self.load_model = load_model
+        self.cached = []
+
+    def cache_embedding_file(self, key, path, cache_dir):
+        self.cached.append((key, path, cache_dir))
+
+    def score_inf(self, baseline_files, eval_files, cache_dir):
+        return DummyFadScore()
+
+    def score(self, baseline_files, eval_files, cache_dir):
+        return 0.5
+
+
+class DummyKidBackend(DummyFadBackend):
+    def score_kid(self, baseline_files, eval_files, cache_dir):
+        return {"_mean": 0.1, "_std": 0.02}
+
+
+def test_fad_metric_registers_and_preserves_output_keys(monkeypatch):
+    monkeypatch.setattr(fad_module, "get_model", lambda embedding: f"model:{embedding}")
+    monkeypatch.setattr(fad_module, "FrechetAudioDistance", DummyFadBackend)
+
+    registry = MetricRegistry()
+    fad_module.register_fad_metric(registry)
+
+    assert registry.get_metric("fad") is fad_module.FadMetric
+    assert registry.get_metadata("fad").category is MetricCategory.DISTRIBUTIONAL
+    assert registry.get_metric("fad_metric") is fad_module.FadMetric
+
+    metric = registry.get_metric("fad")({"io": "kaldi", "use_inf": True})
+    scores = metric.compute(
+        {"utt1": "pred1.wav", "utt2": "pred2.wav"},
+        {"utt1": "ref1.wav", "utt2": "ref2.wav"},
+    )
+
+    assert scores == {"fad_overall": 0.25, "fad_r2": 0.75}
+
+
+def test_kid_metric_registers_and_preserves_output_keys(monkeypatch):
+    monkeypatch.setattr(kid_module, "get_model", lambda embedding: f"model:{embedding}")
+    monkeypatch.setattr(kid_module, "FrechetAudioDistance", DummyKidBackend)
+
+    registry = MetricRegistry()
+    kid_module.register_kid_metric(registry)
+
+    assert registry.get_metric("kid") is kid_module.KidMetric
+    assert registry.get_metadata("kid").category is MetricCategory.DISTRIBUTIONAL
+    assert registry.get_metric("kid_metric") is kid_module.KidMetric
+
+    metric = registry.get_metric("kid")({"io": "kaldi"})
+    scores = metric.compute(
+        {"utt1": "pred1.wav", "utt2": "pred2.wav"},
+        {"utt1": "ref1.wav", "utt2": "ref2.wav"},
+    )
+
+    assert scores == {"kid_mean": 0.1, "kid_std": 0.02}
+
+
+def test_fad_and_kid_raise_clear_error_when_fadtk_missing(monkeypatch):
+    monkeypatch.setattr(fad_module, "get_model", None)
+    monkeypatch.setattr(fad_module, "FrechetAudioDistance", None)
+    monkeypatch.setattr(kid_module, "get_model", None)
+    monkeypatch.setattr(kid_module, "FrechetAudioDistance", None)
+
+    with pytest.raises(ModuleNotFoundError, match="FADTK is not installed"):
+        fad_module.FadMetric()
+
+    with pytest.raises(ModuleNotFoundError, match="FADTK is not installed"):
+        kid_module.KidMetric()
+
+
+def test_default_registry_discovers_reviewed_metrics():
+    registry = _create_populated_registry()
+
+    for metric_name in ["fad", "kid", "asvspoof_score", "emo_vad"]:
+        assert registry.get_metric(metric_name) is not None
+        assert registry.get_metadata(metric_name) is not None
+
+
+def test_distributional_metrics_run_through_corpus_scorer(monkeypatch):
+    monkeypatch.setattr(fad_module, "get_model", lambda embedding: f"model:{embedding}")
+    monkeypatch.setattr(fad_module, "FrechetAudioDistance", DummyFadBackend)
+
+    registry = MetricRegistry()
+    fad_module.register_fad_metric(registry)
+    scorer = VersaScorer(registry)
+    suite = scorer.load_metrics(
+        [{"name": "fad", "io": "kaldi"}],
+        use_gt=True,
+    )
+
+    score_info = scorer.score_corpus(
+        {"utt1": "pred1.wav", "utt2": "pred2.wav"},
+        suite,
+        {"utt1": "ref1.wav", "utt2": "ref2.wav"},
+    )
+
+    assert score_info == {"fad_overall": 0.25, "fad_r2": 0.75}
+
+
+def test_load_score_modules_skips_distributional_metrics(monkeypatch):
+    monkeypatch.setattr(fad_module, "get_model", lambda embedding: f"model:{embedding}")
+    monkeypatch.setattr(fad_module, "FrechetAudioDistance", DummyFadBackend)
+
+    suite = load_score_modules(
+        [{"name": "fad", "io": "kaldi"}],
+        use_gt=True,
+    )
+
+    assert len(suite.metrics) == 0

--- a/test/test_metrics/test_emo_similarity.py
+++ b/test/test_metrics/test_emo_similarity.py
@@ -146,7 +146,7 @@ def test_emotion_metric_metadata():
     metadata = metric.get_metadata()
 
     assert metadata.name == "emotion"
-    assert metadata.category.value == "dependent"
+    assert metadata.category.value == "non_match"
     assert metadata.metric_type.value == "float"
     assert metadata.requires_reference is True
     assert metadata.requires_text is False

--- a/test/test_metrics/test_nomad.py
+++ b/test/test_metrics/test_nomad.py
@@ -135,7 +135,9 @@ class TestNomadMetric:
 
     def test_initialization_without_nomad(self):
         """Test that initialization fails without nomad dependency."""
-        with patch("versa.utterance_metrics.nomad.NOMAD_AVAILABLE", False):
+        with patch("versa.utterance_metrics.nomad.NOMAD_AVAILABLE", False), patch(
+            "versa.utterance_metrics.nomad.Nomad", None
+        ):
             config = {"use_gpu": False, "model_cache": "test_cache"}
             with pytest.raises(ImportError, match="nomad is not installed"):
                 NomadMetric(config)
@@ -233,7 +235,7 @@ class TestNomadMetric:
 
             metadata = metric.get_metadata()
             assert metadata.name == "nomad"
-            assert metadata.category.value == "dependent"
+            assert metadata.category.value == "non_match"
             assert metadata.metric_type.value == "float"
             assert metadata.requires_reference
             assert not metadata.requires_text

--- a/test/test_metrics/test_noresqa.py
+++ b/test/test_metrics/test_noresqa.py
@@ -265,7 +265,7 @@ def test_noresqa_metric_metadata(metric_type):
 
     expected_name = "noresqa_mos" if metric_type == 1 else "noresqa_score"
     assert metadata.name == expected_name
-    assert metadata.category.value == "dependent"
+    assert metadata.category.value == "non_match"
     assert metadata.metric_type.value == "float"
     assert metadata.requires_reference is True
     assert metadata.requires_text is False

--- a/test/test_pipeline/test_base_metrics_pipeline.py
+++ b/test/test_pipeline/test_base_metrics_pipeline.py
@@ -546,10 +546,10 @@ def test_squim_pipeline_with_registry_and_mocked_models(monkeypatch):
     )
 
     assert score_info
-    assert score_info[0]["torch_squim_stoi"] == 0.6
-    assert score_info[0]["torch_squim_pesq"] == 1.2
-    assert score_info[0]["torch_squim_si_sdr"] == -3.4
-    assert score_info[0]["torch_squim_mos"] == 4.2
+    assert score_info[0]["torch_squim_stoi"] == pytest.approx(0.6)
+    assert score_info[0]["torch_squim_pesq"] == pytest.approx(1.2)
+    assert score_info[0]["torch_squim_si_sdr"] == pytest.approx(-3.4)
+    assert score_info[0]["torch_squim_mos"] == pytest.approx(4.2)
 
 
 def test_vad_pipeline_with_registry_and_mocked_model(monkeypatch):
@@ -756,7 +756,7 @@ def test_wer_pipeline_with_registry_and_mocked_models(monkeypatch):
     )
     monkeypatch.setattr(
         "versa.corpus_metrics.whisper_wer.whisper_levenshtein_metric",
-        lambda wer_utils, pred_x, ref_text, fs=16000, cache_pred_text=None, cache_pred_language=None: {
+        lambda wer_utils, pred_x, ref_text, fs=16000, cache_pred_text=None, cache_pred_language=None, **kwargs: {
             "whisper_hyp_text": cache_pred_text or ref_text,
             "whisper_wer_equal": 1,
         },

--- a/test/test_pipeline/test_distributional_real.py
+++ b/test/test_pipeline/test_distributional_real.py
@@ -1,0 +1,100 @@
+import importlib.util
+import math
+import os
+from pathlib import Path
+
+import pytest
+
+from versa.scorer_shared import VersaScorer
+
+RUN_REAL_MODEL_TESTS = os.environ.get("VERSA_RUN_REAL_MODEL_TESTS") == "1"
+
+
+def _fadtk_is_available():
+    try:
+        return (
+            importlib.util.find_spec("fadtk.fad_versa") is not None
+            and importlib.util.find_spec("fadtk.model_loader") is not None
+        )
+    except ModuleNotFoundError:
+        return False
+
+
+def _sample_pair():
+    pred = Path("test/test_samples/test2/test.wav")
+    ref = Path("test/test_samples/test1/test.wav")
+    if not pred.exists() or not ref.exists():
+        pytest.skip("Required real sample audio files are not available")
+    return str(pred), str(ref)
+
+
+@pytest.mark.real_model
+@pytest.mark.skipif(
+    not RUN_REAL_MODEL_TESTS,
+    reason="Set VERSA_RUN_REAL_MODEL_TESTS=1 to run real sample-backed checks",
+)
+@pytest.mark.skipif(
+    not _fadtk_is_available(),
+    reason="FADTK is not installed; run tools/install_fadtk.sh first",
+)
+def test_fad_pipeline_with_real_samples(tmp_path):
+    """Run FAD through the registry/scorer path with real sample audio."""
+    pred, ref = _sample_pair()
+    scorer = VersaScorer()
+    suite = scorer.load_metrics(
+        [
+            {
+                "name": "fad",
+                "io": "soundfile",
+                "cache_dir": str(tmp_path / "fad"),
+                "use_inf": True,
+            }
+        ],
+        use_gt=True,
+    )
+
+    score_info = scorer.score_corpus(
+        {"sample": pred},
+        suite,
+        {"sample": ref},
+    )
+
+    assert set(score_info) == {"fad_overall", "fad_r2"}
+    assert math.isfinite(score_info["fad_overall"])
+    assert isinstance(score_info["fad_r2"], float)
+
+
+@pytest.mark.real_model
+@pytest.mark.skipif(
+    not RUN_REAL_MODEL_TESTS,
+    reason="Set VERSA_RUN_REAL_MODEL_TESTS=1 to run real sample-backed checks",
+)
+@pytest.mark.skipif(
+    not _fadtk_is_available(),
+    reason="FADTK is not installed; run tools/install_fadtk.sh first",
+)
+def test_kid_pipeline_with_real_samples(tmp_path):
+    """Run KID through the registry/scorer path with real sample audio."""
+    pred, ref = _sample_pair()
+    scorer = VersaScorer()
+    suite = scorer.load_metrics(
+        [
+            {
+                "name": "kid",
+                "io": "soundfile",
+                "cache_dir": str(tmp_path / "kid"),
+            }
+        ],
+        use_gt=True,
+    )
+
+    score_info = scorer.score_corpus(
+        {"sample_a": pred, "sample_b": pred},
+        suite,
+        {"sample_a": ref, "sample_b": ref},
+    )
+
+    assert score_info
+    for key, value in score_info.items():
+        assert key.startswith("kid")
+        assert isinstance(value, float)

--- a/test/test_pipeline/test_fad.py
+++ b/test/test_pipeline/test_fad.py
@@ -4,12 +4,7 @@ import os
 
 import yaml
 
-from versa.scorer_shared import (
-    corpus_scoring,
-    find_files,
-    load_corpus_modules,
-    load_summary,
-)
+from versa.scorer_shared import VersaScorer
 
 TEST_INFO = {
     "fad_overall": 0.00753398077542222,
@@ -22,20 +17,13 @@ def info_update():
     with open("egs/separate_metrics/fad.yaml", "r", encoding="utf-8") as f:
         score_config = yaml.safe_load(f)
 
-    score_modules = load_corpus_modules(
-        score_config,
-        use_gpu=False,
-        cache_folder="versa_cache",
-        io="dir",
-    )
-
     assert len(score_config) > 0, "no scoring function is provided"
 
-    score_info = corpus_scoring(
+    scorer = VersaScorer()
+    score_info = scorer.score_corpus(
         "test/test_samples/test2",
-        score_modules,
+        scorer.load_metrics([{**score_config[0], "io": "dir"}], use_gt=True),
         "test/test_samples/test1",
-        output_file=None,
     )
     print("Summary: {}".format(score_info), flush=True)
 
@@ -52,17 +40,10 @@ def info_update():
             )
     print("check dir IO successful", flush=True)
 
-    score_modules = load_corpus_modules(
-        score_config,
-        use_gpu=False,
-        cache_folder="versa_cache",
-        io="kaldi",
-    )
-    score_info = corpus_scoring(
+    score_info = scorer.score_corpus(
         "test/test_samples/test2.scp",
-        score_modules,
+        scorer.load_metrics([{**score_config[0], "io": "kaldi"}], use_gt=True),
         "test/test_samples/test1.scp",
-        output_file=None,
     )
     print("Summary: {}".format(score_info), flush=True)
 
@@ -79,17 +60,10 @@ def info_update():
             )
     print("check kaldi IO successful", flush=True)
 
-    score_modules = load_corpus_modules(
-        score_config,
-        use_gpu=False,
-        cache_folder="versa_cache",
-        io="soundfile",
-    )
-    score_info = corpus_scoring(
+    score_info = scorer.score_corpus(
         "test/test_samples/test2.scp",
-        score_modules,
+        scorer.load_metrics([{**score_config[0], "io": "soundfile"}], use_gt=True),
         "test/test_samples/test1.scp",
-        output_file=None,
     )
     print("Summary: {}".format(score_info), flush=True)
 

--- a/tools/install_fadtk.sh
+++ b/tools/install_fadtk.sh
@@ -1,11 +1,60 @@
-#/bin/bash
+#!/usr/bin/env bash
 
-if [ -d "fadtk" ]; then
-    rm -rf fadtk
+set -euo pipefail
+
+PYTHON=${PYTHON:-python}
+if [[ "${PYTHON}" == */* ]]; then
+    PYTHON="$(cd "$(dirname "${PYTHON}")" && pwd)/$(basename "${PYTHON}")"
+fi
+
+run_as_root_if_needed() {
+    if [ "$(id -u)" -eq 0 ]; then
+        "$@"
+    elif command -v sudo >/dev/null 2>&1; then
+        sudo "$@"
+    else
+        echo "Installing FFmpeg requires root privileges. Please install FFmpeg and rerun this installer." >&2
+        exit 1
+    fi
+}
+
+install_ffmpeg() {
+    if command -v brew >/dev/null 2>&1; then
+        echo "FFmpeg is required by torchcodec/FADTK; installing it with Homebrew..."
+        brew install ffmpeg
+    elif command -v apt-get >/dev/null 2>&1; then
+        echo "FFmpeg is required by torchcodec/FADTK; installing it with apt-get..."
+        run_as_root_if_needed apt-get update
+        run_as_root_if_needed apt-get install -y ffmpeg
+    elif command -v dnf >/dev/null 2>&1; then
+        echo "FFmpeg is required by torchcodec/FADTK; installing it with dnf..."
+        run_as_root_if_needed dnf install -y ffmpeg
+    elif command -v yum >/dev/null 2>&1; then
+        echo "FFmpeg is required by torchcodec/FADTK; installing it with yum..."
+        run_as_root_if_needed yum install -y ffmpeg
+    elif command -v pacman >/dev/null 2>&1; then
+        echo "FFmpeg is required by torchcodec/FADTK; installing it with pacman..."
+        run_as_root_if_needed pacman -Sy --noconfirm ffmpeg
+    else
+        echo "FFmpeg is required by torchcodec/FADTK. Please install FFmpeg and rerun this installer." >&2
+        exit 1
+    fi
+}
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+    install_ffmpeg
 fi
 
 # NOTE(jiatong): a versa-specialized implementation for fadtk
-git clone https://github.com/ftshijt/fadtk.git
+if [ -e "fadtk" ] && [ ! -d "fadtk/.git" ]; then
+    rm -rf fadtk
+fi
+
+if [ ! -d "fadtk/.git" ]; then
+    git clone --depth 1 --filter=blob:none https://github.com/ftshijt/fadtk.git
+fi
+
 cd fadtk
-pip install -e .
+"${PYTHON}" -m pip install -e .
+"${PYTHON}" -m pip install torchcodec
 cd ..

--- a/versa/__init__.py
+++ b/versa/__init__.py
@@ -100,7 +100,16 @@ _optional_metric_import(
     ("ClapScoreMetric", "register_clap_score_metric"),
     "Please install frechet-audio-distance following tools/install_clap_score.sh",
 )
-# from versa.corpus_metrics.fad import FadMetric, register_fad_metric
+_optional_metric_import(
+    "versa.corpus_metrics.fad",
+    ("FadMetric", "register_fad_metric"),
+    "Please install FADTK following tools/install_fadtk.sh",
+)
+_optional_metric_import(
+    "versa.corpus_metrics.kid",
+    ("KidMetric", "register_kid_metric"),
+    "Please install FADTK following tools/install_fadtk.sh",
+)
 _optional_metric_import(
     "versa.corpus_metrics.owsm_wer",
     ("OwsmWerMetric", "register_owsm_wer_metric"),

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -173,11 +173,19 @@ def main():
             and score_metadata[config["name"]].category == MetricCategory.DISTRIBUTIONAL
         )
     ]
+    utterance_score_config = [
+        config
+        for config in score_config
+        if not (
+            score_metadata[config["name"]]
+            and score_metadata[config["name"]].category == MetricCategory.DISTRIBUTIONAL
+        )
+    ]
 
     if args.scoring_mode == "metric":
         score_info = scorer.score_utterances_by_metric(
             gen_files,
-            score_config,
+            utterance_score_config,
             gt_files,
             text_info,
             output_file=args.output_file,
@@ -192,7 +200,7 @@ def main():
     else:
         # Load utterance-level metrics
         utterance_metrics = scorer.load_metrics(
-            score_config,
+            utterance_score_config,
             use_gt=(True if gt_files is not None else False),
             use_gt_text=(True if text_info is not None else False),
             use_gpu=args.use_gpu,

--- a/versa/bin/scorer_chunk.py
+++ b/versa/bin/scorer_chunk.py
@@ -15,14 +15,14 @@ import numpy as np
 import soundfile as sf
 import torch
 import yaml
+from versa.definition import MetricCategory
 from versa.scorer_shared import (
     audio_loader_setup,
-    corpus_scoring,
     list_scoring,
     load_audio,
-    load_corpus_modules,
     load_score_modules,
     load_summary,
+    VersaScorer,
     wav_normalize,
 )
 
@@ -385,11 +385,23 @@ def main():
     else:
         logging.info("No utterance-level scoring function is provided.")
 
-    corpus_score_modules = load_corpus_modules(
-        score_config,
+    scorer = VersaScorer()
+    corpus_score_config = []
+    for config in score_config:
+        metadata = scorer.registry.get_metadata(config["name"])
+        if metadata is None or metadata.category != MetricCategory.DISTRIBUTIONAL:
+            continue
+        corpus_config = dict(config)
+        corpus_config.setdefault("io", args.io)
+        if args.cache_folder and "cache_dir" not in corpus_config:
+            corpus_config["cache_dir"] = str(Path(args.cache_folder) / config["name"])
+        corpus_score_config.append(corpus_config)
+
+    corpus_score_modules = scorer.load_metrics(
+        corpus_score_config,
+        use_gt=(True if args.gt is not None else False),
+        use_gt_text=(True if text_info is not None else False),
         use_gpu=args.use_gpu,
-        cache_folder=args.cache_folder,
-        io=args.io,
     )
     assert (
         len(corpus_score_modules) > 0 or len(score_modules) > 0
@@ -400,15 +412,18 @@ def main():
     # and ensure your corpus scorer supports directory inputs.
     if len(corpus_score_modules) > 0:
         pred_for_corpus = args.pred
+        gt_for_corpus = args.gt if args.gt is not None and not args.no_match else None
         if args.enable_chunking and chunk_tmp_dir is not None:
             # Optionally switch corpus to chunk directory:
             pred_for_corpus = str(chunk_tmp_dir / "pred")
             logging.info(f"Corpus scoring over chunk directory: {pred_for_corpus}")
+            gt_for_corpus = None
 
-        corpus_score_info = corpus_scoring(
+        corpus_score_info = scorer.score_corpus(
             pred_for_corpus,
             corpus_score_modules,
-            args.gt if (args.gt is not None and not args.enable_chunking) else None,
+            gt_for_corpus,
+            text_info,
             output_file=(args.output_file + ".corpus") if args.output_file else None,
         )
         logging.info("Corpus Summary: %s", corpus_score_info)

--- a/versa/corpus_metrics/fad.py
+++ b/versa/corpus_metrics/fad.py
@@ -5,18 +5,15 @@
 
 import logging
 
-import kaldiio
-import librosa
-import numpy as np
-import torch
 from tqdm import tqdm
 
+from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
 from versa.scorer_shared import audio_loader_setup
 
 try:
     from fadtk.fad_versa import FrechetAudioDistance
     from fadtk.model_loader import get_model
-except:
+except ImportError:
     FrechetAudioDistance = None
     get_model = None
     logging.warning(
@@ -24,71 +21,89 @@ except:
     )
 
 
-def fad_setup(
-    baseline,
-    fad_embedding="default",
-    cache_dir="versa_cache/fad",
-    use_inf=True,
-    io="kaldi",
-):
-    if get_model is None or FrechetAudioDistance is None:
-        raise ModuleNotFoundError(
-            "FADTK is not installed. Please install it following `tools/install_fadtk.sh`"
+def _load_audio_collection(audio, io):
+    if isinstance(audio, dict):
+        return audio
+    return audio_loader_setup(audio, io)
+
+
+def _fad_metadata():
+    return MetricMetadata(
+        name="fad",
+        category=MetricCategory.DISTRIBUTIONAL,
+        metric_type=MetricType.DICT,
+        requires_reference=True,
+        requires_text=False,
+        gpu_compatible=True,
+        auto_install=False,
+        dependencies=["fadtk"],
+        description="Frechet Audio Distance over generated and reference audio collections",
+        paper_reference="https://arxiv.org/abs/1812.08466",
+        implementation_source="https://github.com/microsoft/fadtk",
+    )
+
+
+class FadMetric(BaseMetric):
+    """Frechet Audio Distance over prediction and reference collections."""
+
+    def _setup(self):
+        if get_model is None or FrechetAudioDistance is None:
+            raise ModuleNotFoundError(
+                "FADTK is not installed. Please install it following `tools/install_fadtk.sh`"
+            )
+
+        self.cache_dir = self.config.get("cache_dir", "versa_cache/fad")
+        self.use_inf = self.config.get("use_inf", True)
+        self.io = self.config.get("io", "kaldi")
+        self.baseline = self.config.get("baseline")
+        self.embedding = self.config.get("fad_embedding", "default")
+        self.module = FrechetAudioDistance(
+            ml=get_model(self.embedding),
+            load_model=True,
         )
-    # get model
-    model = get_model(fad_embedding)
 
-    # setup fad object
-    fad = FrechetAudioDistance(ml=model, load_model=True)
+    def compute(self, predictions, references=None, metadata=None):
+        if predictions is None:
+            raise ValueError("FAD requires prediction audio files")
 
-    return {
-        "module": fad,
-        "baseline": baseline,
-        "cache_dir": cache_dir,
-        "use_inf": use_inf,
-        "io": io,
-        "embedding": fad_embedding,
-    }
+        metadata = metadata or {}
+        baseline = references or metadata.get("baseline_files") or self.baseline
+        if baseline is None:
+            raise ValueError("FAD requires reference or baseline audio files")
 
+        baseline_files = _load_audio_collection(baseline, self.io)
+        eval_files = _load_audio_collection(predictions, self.io)
 
-def fad_scoring(pred_x, fad_info, key_info="fad"):
+        logging.info("[FAD] caching baseline embeddings...")
+        for key in tqdm(baseline_files.keys()):
+            self.module.cache_embedding_file(
+                key, baseline_files[key], self.cache_dir + "/baseline"
+            )
+        logging.info("[FAD] Finished caching baseline embeddings.")
 
-    cache_dir = fad_info["cache_dir"]
+        logging.info("[FAD] caching eval embeddings...")
+        for key in tqdm(eval_files.keys()):
+            self.module.cache_embedding_file(
+                key, eval_files[key], self.cache_dir + "/eval"
+            )
+        logging.info("[FAD] Finished caching eval embeddings.")
 
-    # 1. Calculate embedding files for each dataset
-    logging.info("[FAD] caching baseline embeddings...")
-    baseline_files = audio_loader_setup(fad_info["baseline"], fad_info["io"])
-    for key in tqdm(baseline_files.keys()):
-        fad_info["module"].cache_embedding_file(
-            key, baseline_files[key], cache_dir + "/baseline"
-        )
-    logging.info("[FAD] Finished caching baseline embeddings.")
+        if self.use_inf or len(baseline_files) != len(eval_files):
+            score = self.module.score_inf(baseline_files, eval_files, self.cache_dir)
+            return {"fad_overall": score.score, "fad_r2": score.r2}
 
-    logging.info("[FAD] caching eval embeddings...")
-    eval_files = audio_loader_setup(pred_x, fad_info["io"])
-    for key in tqdm(eval_files.keys()):
-        fad_info["module"].cache_embedding_file(
-            key, eval_files[key], cache_dir + "/eval"
-        )
-    logging.info("[FAD] Finished caching eval embeddings.")
-
-    if len(baseline_files) != len(eval_files):
-        use_inf = True
-    else:
-        use_inf = fad_info["use_inf"]
-
-    # 2. Calculate FAD
-    if use_inf:
-        score = fad_info["module"].score_inf(baseline_files, eval_files, cache_dir)
         return {
-            "{}_overall".format(key_info): score.score,
-            "{}_r2".format(key_info): score.r2,
+            "fad_overall": self.module.score(baseline_files, eval_files, self.cache_dir)
         }
-    else:
-        score = fad_info["module"].score(baseline_files, eval_files, cache_dir)
-        return {"{}_overall".format(key_info): score}
+
+    def get_metadata(self):
+        return _fad_metadata()
 
 
-if __name__ == "__main__":
-    fad_info = fad_setup("test/test_samples/test1.scp")
-    print(fad_scoring("test/test_samples/test2.scp", fad_info))
+def register_fad_metric(registry):
+    """Register Frechet Audio Distance with the registry."""
+    registry.register(
+        FadMetric,
+        _fad_metadata(),
+        aliases=["frechet_audio_distance", "fad_metric"],
+    )

--- a/versa/corpus_metrics/kid.py
+++ b/versa/corpus_metrics/kid.py
@@ -5,73 +5,107 @@
 
 import logging
 
-import kaldiio
-import librosa
-import numpy as np
-import torch
-from fadtk.fad_versa import FrechetAudioDistance
-from fadtk.model_loader import get_model
 from tqdm import tqdm
 
+from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
 from versa.scorer_shared import audio_loader_setup
 
-
-def kid_setup(
-    baseline,
-    kid_embedding="default",
-    cache_dir="versa_cache/kid",
-    use_inf=True,
-    io="kaldi",
-):
-
-    # get model
-    model = get_model(kid_embedding)
-
-    # setup kid object
-    kid = FrechetAudioDistance(ml=model, load_model=True)
-
-    return {
-        "module": kid,
-        "baseline": baseline,
-        "cache_dir": cache_dir,
-        "use_inf": use_inf,
-        "io": io,
-        "embedding": kid_embedding,
-    }
+try:
+    from fadtk.fad_versa import FrechetAudioDistance
+    from fadtk.model_loader import get_model
+except ImportError:
+    FrechetAudioDistance = None
+    get_model = None
+    logging.warning(
+        "FADTK is not installed. Please install it following `tools/install_fadtk.sh`"
+    )
 
 
-def kid_scoring(pred_x, kid_info, key_info="kid"):
+def _load_audio_collection(audio, io):
+    if isinstance(audio, dict):
+        return audio
+    return audio_loader_setup(audio, io)
 
-    cache_dir = kid_info["cache_dir"]
 
-    # 1. Calculate embedding files for each dataset
-    logging.info("[KID] caching baseline embeddings...")
-    baseline_files = audio_loader_setup(kid_info["baseline"], kid_info["io"])
-    if len(baseline_files) < 2:
-        raise ValueError("KID requires at least 2 files to compare.")
-    for key in tqdm(baseline_files.keys()):
-        kid_info["module"].cache_embedding_file(
-            key, baseline_files[key], cache_dir + "/baseline"
+def _kid_metadata():
+    return MetricMetadata(
+        name="kid",
+        category=MetricCategory.DISTRIBUTIONAL,
+        metric_type=MetricType.DICT,
+        requires_reference=True,
+        requires_text=False,
+        gpu_compatible=True,
+        auto_install=False,
+        dependencies=["fadtk"],
+        description="Kernel distance metric over generated and reference audio embedding distributions",
+        paper_reference="https://arxiv.org/abs/1812.08466",
+        implementation_source="https://github.com/SonyCSLParis/audio-metrics",
+    )
+
+
+class KidMetric(BaseMetric):
+    """Kernel distance metric over prediction and reference collections."""
+
+    def _setup(self):
+        if get_model is None or FrechetAudioDistance is None:
+            raise ModuleNotFoundError(
+                "FADTK is not installed. Please install it following `tools/install_fadtk.sh`"
+            )
+
+        self.cache_dir = self.config.get("cache_dir", "versa_cache/kid")
+        self.io = self.config.get("io", "kaldi")
+        self.baseline = self.config.get("baseline")
+        self.embedding = self.config.get(
+            "kid_embedding", self.config.get("fad_embedding", "default")
         )
-    logging.info("[KID] Finished caching baseline embeddings.")
-
-    logging.info("[KID] caching eval embeddings...")
-    eval_files = audio_loader_setup(pred_x, kid_info["io"])
-    if len(eval_files) < 2:
-        raise ValueError("KID requires at least 2 files to compare.")
-    for key in tqdm(eval_files.keys()):
-        kid_info["module"].cache_embedding_file(
-            key, eval_files[key], cache_dir + "/eval"
+        self.module = FrechetAudioDistance(
+            ml=get_model(self.embedding),
+            load_model=True,
         )
-    logging.info("[KID] Finished caching eval embeddings.")
 
-    # 2. Calculate kid
-    score = kid_info["module"].score_kid(baseline_files, eval_files, cache_dir)
-    # update score key with key_info
-    updated_score = {key_info + key: value for key, value in score.items()}
-    return updated_score
+    def compute(self, predictions, references=None, metadata=None):
+        if predictions is None:
+            raise ValueError("KID requires prediction audio files")
+
+        metadata = metadata or {}
+        baseline = references or metadata.get("baseline_files") or self.baseline
+        if baseline is None:
+            raise ValueError("KID requires reference or baseline audio files")
+
+        baseline_files = _load_audio_collection(baseline, self.io)
+        eval_files = _load_audio_collection(predictions, self.io)
+        if len(baseline_files) < 2 or len(eval_files) < 2:
+            raise ValueError("KID requires at least 2 files to compare.")
+
+        logging.info("[KID] caching baseline embeddings...")
+        for key in tqdm(baseline_files.keys()):
+            self.module.cache_embedding_file(
+                key, baseline_files[key], self.cache_dir + "/baseline"
+            )
+        logging.info("[KID] Finished caching baseline embeddings.")
+
+        logging.info("[KID] caching eval embeddings...")
+        for key in tqdm(eval_files.keys()):
+            self.module.cache_embedding_file(
+                key, eval_files[key], self.cache_dir + "/eval"
+            )
+        logging.info("[KID] Finished caching eval embeddings.")
+
+        return {
+            "kid" + key: value
+            for key, value in self.module.score_kid(
+                baseline_files, eval_files, self.cache_dir
+            ).items()
+        }
+
+    def get_metadata(self):
+        return _kid_metadata()
 
 
-if __name__ == "__main__":
-    kid_info = kid_setup("test/test_samples/test1.scp")
-    print(kid_scoring("test/test_samples/test2.scp", kid_info))
+def register_kid_metric(registry):
+    """Register KID with the registry."""
+    registry.register(
+        KidMetric,
+        _kid_metadata(),
+        aliases=["kernel_distance", "kernel_inception_distance", "kid_metric"],
+    )

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -83,6 +83,15 @@ def load_score_modules(
     """Legacy wrapper for loading utterance-level scoring modules."""
     assert score_config, "no scoring function is provided"
     scorer = VersaScorer(_create_populated_registry())
+    score_config = [
+        config
+        for config in score_config
+        if not (
+            scorer.registry.get_metadata(config["name"])
+            and scorer.registry.get_metadata(config["name"]).category
+            == MetricCategory.DISTRIBUTIONAL
+        )
+    ]
     return scorer.load_metrics(
         score_config,
         use_gt=use_gt,
@@ -118,85 +127,6 @@ def list_scoring(
 def load_summary(score_info: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Legacy alias for summary computation."""
     return compute_summary(score_info)
-
-
-def load_corpus_modules(
-    score_config: List[Dict[str, Any]],
-    use_gpu: bool = False,
-    cache_folder: Optional[str] = None,
-    io: str = "kaldi",
-) -> Dict[str, Any]:
-    """Legacy wrapper for loading corpus-level scoring modules."""
-    assert score_config, "no scoring function is provided"
-    score_modules = {}
-    logger = logging.getLogger(__name__)
-
-    for config in score_config:
-        metric_name = config["name"]
-        try:
-            if metric_name == "fad":
-                from versa.corpus_metrics.fad import fad_setup
-
-                cache_dir = config.get(
-                    "cache_dir",
-                    f"{cache_folder}/fad" if cache_folder else "versa_cache/fad",
-                )
-                score_modules["fad"] = fad_setup(
-                    baseline=None,
-                    fad_embedding=config.get("fad_embedding", "default"),
-                    cache_dir=cache_dir,
-                    use_inf=config.get("use_inf", True),
-                    io=config.get("io", io),
-                )
-            elif metric_name == "kid":
-                from versa.corpus_metrics.kid import kid_setup
-
-                cache_dir = config.get(
-                    "cache_dir",
-                    f"{cache_folder}/kid" if cache_folder else "versa_cache/kid",
-                )
-                score_modules["kid"] = kid_setup(
-                    baseline=None,
-                    kid_embedding=config.get(
-                        "kid_embedding", config.get("fad_embedding", "default")
-                    ),
-                    cache_dir=cache_dir,
-                    use_inf=config.get("use_inf", True),
-                    io=config.get("io", io),
-                )
-        except Exception as e:
-            logger.error("Failed to load corpus metric %s: %s", metric_name, e)
-
-    return score_modules
-
-
-def corpus_scoring(
-    pred_x: str,
-    score_modules: Dict[str, Any],
-    baseline: Optional[str] = None,
-    output_file: Optional[str] = None,
-) -> Dict[str, Any]:
-    """Legacy wrapper for scoring corpus-level metrics."""
-    score_info = {}
-
-    for metric_name, module_info in score_modules.items():
-        if baseline is not None:
-            module_info["baseline"] = baseline
-
-        if metric_name == "fad":
-            from versa.corpus_metrics.fad import fad_scoring
-
-            score_info.update(fad_scoring(pred_x, module_info, key_info="fad"))
-        elif metric_name == "kid":
-            from versa.corpus_metrics.kid import kid_scoring
-
-            score_info.update(kid_scoring(pred_x, module_info, key_info="kid"))
-
-    if output_file:
-        with open(output_file, "w") as f:
-            yaml.dump(score_info, f)
-
-    return score_info
 
 
 def _load_existing_jsonl_scores(

--- a/versa/utterance_metrics/emo_similarity.py
+++ b/versa/utterance_metrics/emo_similarity.py
@@ -131,7 +131,7 @@ class Emo2vecMetric(BaseMetric):
         """Return Emotion metric metadata."""
         return MetricMetadata(
             name="emotion",
-            category=MetricCategory.DEPENDENT,
+            category=MetricCategory.NON_MATCH,
             metric_type=MetricType.FLOAT,
             requires_reference=True,
             requires_text=False,
@@ -148,7 +148,7 @@ def register_emo2vec_metric(registry):
     """Register Emotion metric with the registry."""
     metric_metadata = MetricMetadata(
         name="emotion",
-        category=MetricCategory.DEPENDENT,
+        category=MetricCategory.NON_MATCH,
         metric_type=MetricType.FLOAT,
         requires_reference=True,
         requires_text=False,

--- a/versa/utterance_metrics/nomad.py
+++ b/versa/utterance_metrics/nomad.py
@@ -115,7 +115,7 @@ class NomadMetric(BaseMetric):
         """Return NOMAD metric metadata."""
         return MetricMetadata(
             name="nomad",
-            category=MetricCategory.DEPENDENT,
+            category=MetricCategory.NON_MATCH,
             metric_type=MetricType.FLOAT,
             requires_reference=True,
             requires_text=False,
@@ -132,7 +132,7 @@ def register_nomad_metric(registry):
     """Register NOMAD metric with the registry."""
     metric_metadata = MetricMetadata(
         name="nomad",
-        category=MetricCategory.DEPENDENT,
+        category=MetricCategory.NON_MATCH,
         metric_type=MetricType.FLOAT,
         requires_reference=True,
         requires_text=False,

--- a/versa/utterance_metrics/noresqa.py
+++ b/versa/utterance_metrics/noresqa.py
@@ -243,7 +243,7 @@ class NoresqaMetric(BaseMetric):
 
         return MetricMetadata(
             name=metric_name,
-            category=MetricCategory.DEPENDENT,
+            category=MetricCategory.NON_MATCH,
             metric_type=MetricType.FLOAT,
             requires_reference=True,
             requires_text=False,
@@ -267,7 +267,7 @@ def register_noresqa_metric(registry):
 
         metric_metadata = MetricMetadata(
             name=metric_name,
-            category=MetricCategory.DEPENDENT,
+            category=MetricCategory.NON_MATCH,
             metric_type=MetricType.FLOAT,
             requires_reference=True,
             requires_text=False,


### PR DESCRIPTION
## Summary
- Migrate FAD and KID to registry-backed distributional metric classes.
- Add metric review plan docs, Qwen-Omni docs/example coverage, registry exports, and metadata/category fixes.
- Add mocked distributional metric tests plus real sample-backed FAD/KID pipeline tests.
- Update the FADTK installer to install/check FFmpeg on macOS and common Linux package managers.

## Validation
- `PYTHON=.codex-test-venv/bin/python tools/install_fadtk.sh`
- `VERSA_RUN_REAL_MODEL_TESTS=1 .codex-test-venv/bin/python -m pytest test/test_pipeline/test_distributional_real.py -q`
- `.codex-test-venv/bin/python -m pytest test/test_metrics/test_distributional_metrics.py test/test_metrics/test_definition.py -q`
- `.codex-test-venv/bin/python -m pytest test/test_pipeline/test_base_metrics_pipeline.py -q`
- `.codex-test-venv/bin/python -m black --check ...`
- `.codex-test-venv/bin/python -m flake8 --select=E9,F63,F7,F82 ...`
- `bash -n tools/install_fadtk.sh`

## Notes
- Real FAD/KID tests require `VERSA_RUN_REAL_MODEL_TESTS=1`.
- First real-model run may need network access for FADTK/Hugging Face model files.