### PR TITLE
Add metric discovery CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,29 @@ long-running evaluations that are interrupted or restarted.
 metric resources before moving to the next metric. This can reduce peak GPU
 memory when many model-backed metrics are configured together.
 
+### Metric Discovery
+
+Use the `versa-score` CLI to inspect available metrics and generate starter
+configs without reading the full metrics table manually:
+
+```bash
+# List metrics registered in the current environment
+versa-score --list-metrics
+
+# Show metadata, dependencies, references, and aliases for one metric
+versa-score --describe-metric pesq
+
+# Print a recommended YAML score config for a task/device pair
+versa-score --recommend-config --task tts --device gpu
+```
+
+`--list-metrics` also supports `--metric-category` and `--metric-type` filters,
+for example:
+
+```bash
+versa-score --list-metrics --metric-category dependent --metric-type float
+```
+
 ### Distributed Evaluation with Slurm
 
 ```bash

--- a/test/test_metrics/test_definition.py
+++ b/test/test_metrics/test_definition.py
@@ -13,6 +13,12 @@ from versa.definition import (
     MetricSuite,
     MetricType,
 )
+from versa.metric_discovery import (
+    create_metric_discovery_registry,
+    describe_metric,
+    format_metric_list,
+    recommend_config,
+)
 from versa.scorer_shared import VersaScorer, compute_summary
 from versa.utils_shared import find_files
 
@@ -62,6 +68,40 @@ def test_metric_factory_create_suite_with_missing_dependency_and_default_config(
     suite = MetricFactory(registry).create_metric_suite(["dummy"])
 
     assert suite.compute_all(predictions=None) == {"dummy": {"dummy": 1.0}}
+
+
+def test_metric_registry_lists_aliases_for_metric():
+    registry = MetricRegistry()
+    registry.register(DummyMetric, DUMMY_METADATA, aliases=["dummy_alias"])
+
+    assert registry.get_aliases("dummy") == ["dummy_alias"]
+    assert registry.get_aliases("dummy_alias") == ["dummy_alias"]
+    assert registry.list_aliases() == {"dummy_alias": "dummy"}
+
+
+def test_metric_discovery_describes_metric_without_instantiating_backend():
+    registry = create_metric_discovery_registry()
+
+    assert "pesq" in registry.list_metrics()
+    assert "PESQ: Perceptual Evaluation" in describe_metric(registry, "pesq")
+
+
+def test_metric_discovery_formats_filtered_list():
+    registry = create_metric_discovery_registry()
+
+    output = format_metric_list(registry)
+
+    assert "name" in output
+    assert "pesq" in output
+    assert "metric(s) available" in output
+
+
+def test_metric_discovery_recommends_tts_gpu_config():
+    output = recommend_config("tts", "gpu")
+
+    assert "task=tts, device=gpu" in output
+    assert "- name: discrete_speech" in output
+    assert "- name: whisper_wer" in output
 
 
 def test_metric_suite_compute_parallel_is_explicitly_unimplemented():

--- a/versa/__init__.py
+++ b/versa/__init__.py
@@ -1,6 +1,7 @@
 import importlib
 import logging
 import os
+import sys
 from pathlib import Path
 from importlib.metadata import PackageNotFoundError, version
 
@@ -15,9 +16,17 @@ os.environ.setdefault(
     "NUMBA_CACHE_DIR", str(Path.cwd() / "versa_cache" / "numba_cache")
 )
 
+_SKIP_OPTIONAL_METRIC_IMPORTS = any(
+    flag in sys.argv
+    for flag in ("--list-metrics", "--describe-metric", "--recommend-config")
+)
+
 
 def _optional_metric_import(module_name, names, install_hint=None):
     """Import optional metric symbols without making package import fail."""
+    if _SKIP_OPTIONAL_METRIC_IMPORTS:
+        return
+
     try:
         module = importlib.import_module(module_name)
     except ImportError:

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -8,14 +8,14 @@
 import argparse
 import logging
 
-import torch
-import yaml
-
-from versa.definition import MetricCategory
-from versa.scorer_shared import (
-    audio_loader_setup,
-    VersaScorer,
-    compute_summary,
+from versa.metric_discovery import (
+    create_metric_discovery_registry,
+    describe_metric,
+    format_metric_list,
+    parse_metric_category,
+    parse_metric_type,
+    recommend_config,
+    supported_recommendation_tasks,
 )
 
 
@@ -93,11 +93,99 @@ def get_parser() -> argparse.Namespace:
             "reducing peak GPU memory when many metrics are configured."
         ),
     )
+    parser.add_argument(
+        "--list-metrics",
+        action="store_true",
+        help="List registered metrics and exit.",
+    )
+    parser.add_argument(
+        "--describe-metric",
+        type=str,
+        default=None,
+        metavar="NAME",
+        help="Describe one metric by name or alias and exit.",
+    )
+    parser.add_argument(
+        "--recommend-config",
+        action="store_true",
+        help="Print a recommended YAML score config and exit.",
+    )
+    parser.add_argument(
+        "--task",
+        type=str,
+        default=None,
+        help=(
+            "Task for --recommend-config. Supported tasks: "
+            + ", ".join(supported_recommendation_tasks())
+        ),
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cpu",
+        choices=["cpu", "gpu"],
+        help="Target device for --recommend-config.",
+    )
+    parser.add_argument(
+        "--metric-category",
+        type=str,
+        default=None,
+        choices=["independent", "dependent", "non_match", "distributional"],
+        help="Filter --list-metrics by metric category.",
+    )
+    parser.add_argument(
+        "--metric-type",
+        type=str,
+        default=None,
+        choices=[
+            "string",
+            "float",
+            "int",
+            "bool",
+            "list",
+            "dict",
+            "tuple",
+            "array",
+            "time",
+        ],
+        help="Filter --list-metrics by output type.",
+    )
     return parser
 
 
 def main():
-    args = get_parser().parse_args()
+    parser = get_parser()
+    args = parser.parse_args()
+
+    if args.list_metrics or args.describe_metric or args.recommend_config:
+        try:
+            if args.list_metrics:
+                registry = create_metric_discovery_registry()
+                category = parse_metric_category(args.metric_category)
+                metric_type = parse_metric_type(args.metric_type)
+                print(format_metric_list(registry, category, metric_type))
+                return
+            if args.describe_metric:
+                registry = create_metric_discovery_registry()
+                print(describe_metric(registry, args.describe_metric))
+                return
+            if args.recommend_config:
+                if not args.task:
+                    parser.error("--recommend-config requires --task")
+                print(recommend_config(args.task, args.device))
+                return
+        except ValueError as e:
+            parser.error(str(e))
+
+    import torch
+
+    from versa.definition import MetricCategory
+    from versa.scorer_shared import (
+        audio_loader_setup,
+        VersaScorer,
+        compute_summary,
+    )
+    import yaml
 
     # In case of using `local` backend, all GPU will be visible to all process.
     if args.use_gpu:

--- a/versa/definition.py
+++ b/versa/definition.py
@@ -75,6 +75,19 @@ class MetricRegistry:
         real_name = self._aliases.get(name, name)
         return self._metadata.get(real_name)
 
+    def get_aliases(self, name: str) -> List[str]:
+        """Get aliases registered for a metric name or alias."""
+        real_name = self._aliases.get(name, name)
+        return sorted(
+            alias
+            for alias, metric_name in self._aliases.items()
+            if metric_name == real_name
+        )
+
+    def list_aliases(self) -> Dict[str, str]:
+        """List registered aliases mapped to canonical metric names."""
+        return dict(sorted(self._aliases.items()))
+
     def list_metrics(
         self, category: MetricCategory = None, metric_type: MetricType = None
     ) -> List[str]:

--- a/versa/metric_discovery.py
+++ b/versa/metric_discovery.py
@@ -1,0 +1,628 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Jiatong Shi
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Helpers for discovering metrics from the command line."""
+
+import ast
+import contextlib
+import io
+import logging
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+try:
+    import yaml
+except ImportError:
+    yaml = None
+
+from versa.definition import MetricCategory, MetricRegistry, MetricType
+
+_MCD_F0_DEFAULTS = {
+    "name": "mcd_f0",
+    "f0min": 40,
+    "f0max": 800,
+    "mcep_shift": 5,
+    "mcep_fftl": 1024,
+    "mcep_dim": 39,
+    "mcep_alpha": 0.466,
+    "seq_mismatch_tolerance": 0.1,
+    "power_threshold": -20,
+    "dtw": True,
+}
+
+_PSEUDO_MOS_UTMOS = {
+    "name": "pseudo_mos",
+    "predictor_types": ["utmos"],
+    "predictor_args": {"utmos": {"fs": 16000}},
+}
+
+_RECOMMENDED_CONFIGS: Dict[str, Dict[str, List[Dict[str, Any]]]] = {
+    "tts": {
+        "cpu": [
+            _MCD_F0_DEFAULTS,
+            {"name": "pesq"},
+            {"name": "stoi"},
+            _PSEUDO_MOS_UTMOS,
+            {"name": "speaking_rate"},
+        ],
+        "gpu": [
+            _MCD_F0_DEFAULTS,
+            {"name": "discrete_speech"},
+            _PSEUDO_MOS_UTMOS,
+            {"name": "whisper_wer", "model_tag": "default", "beam_size": 1},
+            {"name": "speaker", "model_tag": "default"},
+            {"name": "asr_match", "model_tag": "default", "beam_size": 1},
+            {"name": "audiobox_aesthetics", "batch_size": 1},
+        ],
+    },
+    "codec": {
+        "cpu": [
+            _MCD_F0_DEFAULTS,
+            {"name": "signal_metric"},
+            {"name": "pesq"},
+            {"name": "stoi"},
+            _PSEUDO_MOS_UTMOS,
+        ],
+        "gpu": [
+            _MCD_F0_DEFAULTS,
+            {"name": "signal_metric"},
+            {"name": "pesq"},
+            {"name": "stoi"},
+            {"name": "discrete_speech"},
+            _PSEUDO_MOS_UTMOS,
+            {"name": "speaker", "model_tag": "default"},
+        ],
+    },
+    "se": {
+        "cpu": [
+            {"name": "signal_metric"},
+            {"name": "pesq"},
+            {"name": "stoi"},
+            {"name": "srmr"},
+            {"name": "pysepm"},
+        ],
+        "gpu": [
+            {"name": "signal_metric"},
+            {"name": "pesq"},
+            {"name": "stoi"},
+            {"name": "squim_ref"},
+            {"name": "squim_no_ref"},
+            {"name": "se_snr"},
+        ],
+    },
+    "svs": {
+        "cpu": [
+            _MCD_F0_DEFAULTS,
+            _PSEUDO_MOS_UTMOS,
+            {"name": "speaker", "model_tag": "default"},
+        ],
+        "gpu": [
+            _MCD_F0_DEFAULTS,
+            _PSEUDO_MOS_UTMOS,
+            {"name": "singer"},
+            {"name": "speaker", "model_tag": "default"},
+            {"name": "qwen_omni_singing_technique"},
+        ],
+    },
+}
+
+_TASK_ALIASES = {
+    "speech-enhancement": "se",
+    "speech_enhancement": "se",
+    "enhancement": "se",
+    "singing": "svs",
+}
+
+
+def create_metric_discovery_registry() -> MetricRegistry:
+    """Create the registry used by discovery commands."""
+    with _quiet_metric_imports():
+        import versa as versa_package
+
+        registry = MetricRegistry()
+        for name in dir(versa_package):
+            if not name.startswith("register_") or not name.endswith("_metric"):
+                continue
+            register_fn = getattr(versa_package, name)
+            if callable(register_fn):
+                try:
+                    register_fn(registry)
+                except Exception as e:
+                    logging.getLogger(__name__).debug(
+                        "Failed to register metric via %s: %s", name, e
+                    )
+    _add_source_discovered_metrics(registry)
+    return registry
+
+
+def parse_metric_category(value: Optional[str]) -> Optional[MetricCategory]:
+    """Parse a category filter from the CLI."""
+    if value is None:
+        return None
+    try:
+        return MetricCategory(value)
+    except ValueError as exc:
+        choices = ", ".join(category.value for category in MetricCategory)
+        raise ValueError(
+            f"Unknown metric category '{value}'. Choices: {choices}"
+        ) from exc
+
+
+def parse_metric_type(value: Optional[str]) -> Optional[MetricType]:
+    """Parse a metric type filter from the CLI."""
+    if value is None:
+        return None
+    try:
+        return MetricType(value)
+    except ValueError as exc:
+        choices = ", ".join(metric_type.value for metric_type in MetricType)
+        raise ValueError(f"Unknown metric type '{value}'. Choices: {choices}") from exc
+
+
+def format_metric_list(
+    registry: MetricRegistry,
+    category: Optional[MetricCategory] = None,
+    metric_type: Optional[MetricType] = None,
+) -> str:
+    """Format registered metrics as a compact table."""
+    metrics = registry.list_metrics(category=category, metric_type=metric_type)
+    rows = []
+    for name in metrics:
+        metadata = registry.get_metadata(name)
+        rows.append(
+            [
+                metadata.name,
+                metadata.category.value,
+                metadata.metric_type.value,
+                "yes" if metadata.requires_reference else "no",
+                "yes" if metadata.requires_text else "no",
+                "yes" if metadata.gpu_compatible else "no",
+                "yes" if metadata.auto_install else "no",
+            ]
+        )
+
+    headers = ["name", "category", "type", "ref", "text", "gpu", "auto"]
+    table = _format_table(headers, rows)
+    return f"{table}\n\n{len(rows)} metric(s) available."
+
+
+def describe_metric(registry: MetricRegistry, metric_name: str) -> str:
+    """Describe one registered metric."""
+    metadata = registry.get_metadata(metric_name)
+    if metadata is None:
+        suggestions = _suggest_metric_names(registry, metric_name)
+        message = f"Metric '{metric_name}' was not found."
+        if suggestions:
+            message += "\nDid you mean: " + ", ".join(suggestions) + "?"
+        raise ValueError(message)
+
+    aliases = [
+        alias for alias in registry.get_aliases(metric_name) if alias != metadata.name
+    ]
+    lines = [
+        f"name: {metadata.name}",
+        f"category: {metadata.category.value}",
+        f"type: {metadata.metric_type.value}",
+        f"requires_reference: {str(metadata.requires_reference).lower()}",
+        f"requires_text: {str(metadata.requires_text).lower()}",
+        f"gpu_compatible: {str(metadata.gpu_compatible).lower()}",
+        f"auto_install: {str(metadata.auto_install).lower()}",
+        "dependencies: " + (", ".join(metadata.dependencies) or "none"),
+    ]
+    if aliases:
+        lines.append("aliases: " + ", ".join(aliases))
+    lines.append(f"description: {metadata.description}")
+    if metadata.paper_reference:
+        lines.append(f"paper_reference: {metadata.paper_reference}")
+    if metadata.implementation_source:
+        lines.append(f"implementation_source: {metadata.implementation_source}")
+
+    return "\n".join(lines)
+
+
+def recommend_config(task: str, device: str) -> str:
+    """Return a recommended score config as YAML."""
+    task_key = _TASK_ALIASES.get(task.lower(), task.lower())
+    device_key = device.lower()
+
+    if task_key not in _RECOMMENDED_CONFIGS:
+        choices = ", ".join(sorted(_RECOMMENDED_CONFIGS))
+        raise ValueError(f"Unknown task '{task}'. Choices: {choices}")
+    if device_key not in _RECOMMENDED_CONFIGS[task_key]:
+        choices = ", ".join(sorted(_RECOMMENDED_CONFIGS[task_key]))
+        raise ValueError(f"Unknown device '{device}'. Choices: {choices}")
+
+    config = _RECOMMENDED_CONFIGS[task_key][device_key]
+    header = [
+        f"# Recommended VERSA score config for task={task_key}, device={device_key}",
+        "# Save this YAML and pass it with --score_config.",
+    ]
+    body = _safe_dump_yaml(config)
+    return "\n".join(header) + "\n" + body
+
+
+def supported_recommendation_tasks() -> Iterable[str]:
+    """Return tasks with built-in recommendations."""
+    return sorted(_RECOMMENDED_CONFIGS)
+
+
+@contextlib.contextmanager
+def _quiet_metric_imports():
+    previous_disable_level = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    with contextlib.redirect_stderr(io.StringIO()):
+        try:
+            yield
+        finally:
+            logging.disable(previous_disable_level)
+
+
+def _format_table(headers: List[str], rows: List[List[str]]) -> str:
+    widths = [
+        max(len(str(row[index])) for row in [headers] + rows)
+        for index in range(len(headers))
+    ]
+    lines = [
+        "  ".join(
+            str(value).ljust(widths[index]) for index, value in enumerate(headers)
+        ),
+        "  ".join("-" * width for width in widths),
+    ]
+    for row in rows:
+        lines.append(
+            "  ".join(
+                str(value).ljust(widths[index]) for index, value in enumerate(row)
+            )
+        )
+    return "\n".join(lines)
+
+
+def _safe_dump_yaml(config: List[Dict[str, Any]]) -> str:
+    if yaml is not None:
+        return yaml.safe_dump(config, sort_keys=False)
+    return "\n".join(_dump_yaml_item(item) for item in config) + "\n"
+
+
+def _dump_yaml_item(item: Dict[str, Any]) -> str:
+    lines = []
+    first = True
+    for key, value in item.items():
+        prefix = "- " if first else "  "
+        first = False
+        if isinstance(value, dict):
+            lines.append(f"{prefix}{key}:")
+            lines.extend(_dump_yaml_dict(value, indent=4))
+        else:
+            lines.append(f"{prefix}{key}: {_dump_yaml_scalar(value)}")
+    return "\n".join(lines)
+
+
+def _dump_yaml_dict(item: Dict[str, Any], indent: int) -> List[str]:
+    lines = []
+    padding = " " * indent
+    for key, value in item.items():
+        if isinstance(value, dict):
+            lines.append(f"{padding}{key}:")
+            lines.extend(_dump_yaml_dict(value, indent + 2))
+        else:
+            lines.append(f"{padding}{key}: {_dump_yaml_scalar(value)}")
+    return lines
+
+
+def _dump_yaml_scalar(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "[" + ", ".join(_dump_yaml_scalar(item) for item in value) + "]"
+    return str(value)
+
+
+def _add_source_discovered_metrics(registry: MetricRegistry) -> None:
+    package_root = Path(__file__).resolve().parent
+    for path in package_root.rglob("*.py"):
+        if path.name.startswith("__"):
+            continue
+        for metadata, aliases in _discover_module_metadata(path):
+            if registry.get_metadata(metadata.name):
+                continue
+            registry.register(_DiscoveredMetric, metadata, aliases=aliases)
+
+
+def _discover_module_metadata(path: Path) -> List[Tuple[Any, List[str]]]:
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return []
+
+    assigned_metadata = {}
+    function_metadata = {}
+    discovered = _discover_prompt_metrics(path, tree)
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        for child in ast.walk(node):
+            if isinstance(child, ast.Return):
+                metadata = _metadata_from_call(child.value)
+                if metadata is not None:
+                    function_metadata[node.name] = metadata
+                    discovered.append((metadata, []))
+                    break
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        metadata = _metadata_from_call(node.value)
+        if metadata is None:
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name):
+                assigned_metadata[target.id] = metadata
+        discovered.append((metadata, []))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not _is_register_call(node.func):
+            continue
+        metadata = _metadata_from_register_call(
+            node, assigned_metadata, function_metadata
+        )
+        if metadata is None:
+            continue
+        aliases = _aliases_from_register_call(node)
+        discovered.append((metadata, aliases))
+
+    unique = {}
+    for metadata, aliases in discovered:
+        unique[metadata.name] = (metadata, aliases)
+    return list(unique.values())
+
+
+def _discover_prompt_metrics(path: Path, tree: ast.AST) -> List[Tuple[Any, List[str]]]:
+    from versa.definition import MetricMetadata
+
+    prompt_names = _default_prompt_names(tree)
+    if not prompt_names and path.name == "qwen_omni.py":
+        prompt_names = _default_prompt_names(
+            ast.parse((path.parent / "qwen2_audio.py").read_text(encoding="utf-8"))
+        )
+    if not prompt_names:
+        return []
+
+    if path.name == "qwen2_audio.py":
+        return [
+            (
+                MetricMetadata(
+                    name=f"qwen2_audio_{prompt_name}",
+                    category=MetricCategory.INDEPENDENT,
+                    metric_type=MetricType.STRING,
+                    requires_reference=False,
+                    requires_text=False,
+                    gpu_compatible=True,
+                    auto_install=False,
+                    dependencies=["transformers", "librosa", "numpy"],
+                    description="Speech property extraction with Qwen2-Audio",
+                    paper_reference="https://arxiv.org/abs/2407.10759",
+                    implementation_source="https://github.com/QwenLM/Qwen2-Audio",
+                ),
+                [
+                    f"qwen2_{prompt_name}_metric",
+                    f"qwen_{prompt_name}",
+                ],
+            )
+            for prompt_name in prompt_names
+        ]
+
+    if path.name == "qwen_omni.py":
+        return [
+            (
+                MetricMetadata(
+                    name=f"qwen_omni_{prompt_name}",
+                    category=MetricCategory.INDEPENDENT,
+                    metric_type=MetricType.STRING,
+                    requires_reference=False,
+                    requires_text=False,
+                    gpu_compatible=True,
+                    auto_install=False,
+                    dependencies=["transformers", "librosa", "numpy", "torch"],
+                    description="Speech property extraction with Qwen2.5-Omni",
+                    paper_reference="https://arxiv.org/abs/2503.20215",
+                    implementation_source="https://github.com/QwenLM/Qwen2.5-Omni",
+                ),
+                [f"qwen_omni_{prompt_name}_metric"],
+            )
+            for prompt_name in prompt_names
+        ]
+
+    return []
+
+
+def _default_prompt_names(tree: ast.AST) -> List[str]:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "DEFAULT_PROMPTS"
+            for target in node.targets
+        ):
+            continue
+        if isinstance(node.value, ast.Dict):
+            return [
+                key.value
+                for key in node.value.keys
+                if isinstance(key, ast.Constant) and isinstance(key.value, str)
+            ]
+    return []
+
+
+def _metadata_from_register_call(
+    node: ast.Call,
+    assigned_metadata: Dict[str, Any],
+    function_metadata: Dict[str, Any],
+) -> Optional[Any]:
+    if len(node.args) < 2:
+        return None
+    metadata_arg = node.args[1]
+    if isinstance(metadata_arg, ast.Name):
+        return assigned_metadata.get(metadata_arg.id)
+    if isinstance(metadata_arg, ast.Call) and isinstance(metadata_arg.func, ast.Name):
+        return function_metadata.get(
+            metadata_arg.func.id
+        ) or _metadata_from_known_helper(metadata_arg)
+    return _metadata_from_call(metadata_arg)
+
+
+def _metadata_from_known_helper(node: ast.Call) -> Optional[Any]:
+    from versa.definition import MetricMetadata
+
+    if not isinstance(node.func, ast.Name):
+        return None
+
+    args = [_literal_metric_value(arg) for arg in node.args]
+    if node.func.id == "_squim_metadata" and len(args) >= 2:
+        name, mode = args[:2]
+        requires_reference = mode == "ref"
+        return MetricMetadata(
+            name=name,
+            category=(
+                MetricCategory.DEPENDENT
+                if requires_reference
+                else MetricCategory.INDEPENDENT
+            ),
+            metric_type=MetricType.DICT,
+            requires_reference=requires_reference,
+            requires_text=False,
+            gpu_compatible=False,
+            auto_install=False,
+            dependencies=["torch", "torchaudio"],
+            description=(
+                "TorchAudio-SQUIM subjective MOS metric"
+                if requires_reference
+                else "TorchAudio-SQUIM reference-less PESQ, STOI, and SI-SDR metrics"
+            ),
+            paper_reference="https://arxiv.org/abs/2302.01147",
+            implementation_source=(
+                "https://pytorch.org/audio/main/tutorials/squim_tutorial.html"
+            ),
+        )
+
+    if node.func.id == "_scoreq_metadata" and len(args) >= 2:
+        name, mode = args[:2]
+        requires_reference = mode == "ref"
+        return MetricMetadata(
+            name=name,
+            category=(
+                MetricCategory.DEPENDENT
+                if requires_reference
+                else MetricCategory.INDEPENDENT
+            ),
+            metric_type=MetricType.FLOAT,
+            requires_reference=requires_reference,
+            requires_text=False,
+            gpu_compatible=True,
+            auto_install=False,
+            dependencies=["scoreq_versa", "torch", "librosa", "numpy"],
+            description=(
+                "ScoreQ reference-based speech quality assessment"
+                if requires_reference
+                else "ScoreQ reference-less speech quality assessment"
+            ),
+            paper_reference="https://arxiv.org/pdf/2410.06675",
+            implementation_source="https://github.com/ftshijt/scoreq",
+        )
+
+    return None
+
+
+def _metadata_from_call(node: ast.AST) -> Optional[Any]:
+    from versa.definition import MetricMetadata
+
+    if not isinstance(node, ast.Call) or not _is_name(node.func, "MetricMetadata"):
+        return None
+
+    values = {}
+    positional_fields = [
+        "name",
+        "category",
+        "metric_type",
+        "requires_reference",
+        "requires_text",
+        "gpu_compatible",
+        "auto_install",
+        "dependencies",
+        "description",
+        "paper_reference",
+        "implementation_source",
+    ]
+    for field, value in zip(positional_fields, node.args):
+        values[field] = _literal_metric_value(value)
+    for keyword in node.keywords:
+        if keyword.arg:
+            values[keyword.arg] = _literal_metric_value(keyword.value)
+
+    required_fields = positional_fields[:9]
+    if any(field not in values for field in required_fields):
+        return None
+    if any(values[field] is None for field in required_fields):
+        return None
+
+    try:
+        return MetricMetadata(**values)
+    except (TypeError, ValueError):
+        return None
+
+
+def _literal_metric_value(node: ast.AST) -> Any:
+    from versa.definition import MetricCategory, MetricType
+
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        if node.value.id == "MetricCategory":
+            return MetricCategory[node.attr]
+        if node.value.id == "MetricType":
+            return MetricType[node.attr]
+    if isinstance(node, ast.List):
+        return [_literal_metric_value(item) for item in node.elts]
+    if isinstance(node, ast.Tuple):
+        return tuple(_literal_metric_value(item) for item in node.elts)
+    if isinstance(node, ast.Dict):
+        return {
+            _literal_metric_value(key): _literal_metric_value(value)
+            for key, value in zip(node.keys, node.values)
+        }
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError):
+        return None
+
+
+def _aliases_from_register_call(node: ast.Call) -> List[str]:
+    alias_node = None
+    if len(node.args) >= 3:
+        alias_node = node.args[2]
+    for keyword in node.keywords:
+        if keyword.arg == "aliases":
+            alias_node = keyword.value
+            break
+    aliases = _literal_metric_value(alias_node) if alias_node is not None else []
+    return aliases if isinstance(aliases, list) else []
+
+
+def _is_register_call(node: ast.AST) -> bool:
+    return isinstance(node, ast.Attribute) and node.attr == "register"
+
+
+def _is_name(node: ast.AST, name: str) -> bool:
+    return isinstance(node, ast.Name) and node.id == name
+
+
+class _DiscoveredMetric:
+    """Placeholder metric class for metadata-only discovery."""
+
+
+def _suggest_metric_names(registry: MetricRegistry, metric_name: str) -> List[str]:
+    query = metric_name.lower()
+    names = set(registry.list_metrics()) | set(registry.list_aliases())
+    return sorted(name for name in names if query in name.lower())[:5]


### PR DESCRIPTION
## Summary
- add `versa-score` discovery flags for listing metrics, describing a metric, and recommending task/device configs
- add metadata-only discovery fallback so optional metric backends do not need to import for CLI discovery
- expose metric alias lookup helpers and cover discovery behavior in tests

## Tests
- `.codex-test-venv/bin/python -m pytest test/test_metrics/test_definition.py`
- `.codex-test-venv/bin/versa-score --list-metrics`
- `.codex-test-venv/bin/versa-score --describe-metric pesq`
- `.codex-test-venv/bin/versa-score --recommend-config --task tts --device gpu`