### PR TITLE
[codex] Add score config validation

### DIFF
--- a/test/test_metrics/test_definition.py
+++ b/test/test_metrics/test_definition.py
@@ -13,6 +13,10 @@ from versa.definition import (
     MetricSuite,
     MetricType,
 )
+from versa.config_validation import (
+    ScoreConfigValidationException,
+    validate_score_config,
+)
 from versa.metric_discovery import (
     create_metric_discovery_registry,
     describe_metric,
@@ -39,7 +43,7 @@ calculate_average_wer = _load_calculate_average_wer()
 
 class DummyMetric(BaseMetric):
     def _setup(self):
-        pass
+        self.threshold = self.config.get("threshold", 0.5)
 
     def compute(self, predictions, references=None, metadata=None):
         return {"dummy": 1.0}
@@ -61,6 +65,12 @@ DUMMY_METADATA = MetricMetadata(
 )
 
 
+def _registry_with_dummy(metadata=DUMMY_METADATA):
+    registry = MetricRegistry()
+    registry.register(DummyMetric, metadata, aliases=["dummy_alias"])
+    return registry
+
+
 def test_metric_factory_create_suite_with_missing_dependency_and_default_config():
     registry = MetricRegistry()
     registry.register(DummyMetric, DUMMY_METADATA)
@@ -71,12 +81,82 @@ def test_metric_factory_create_suite_with_missing_dependency_and_default_config(
 
 
 def test_metric_registry_lists_aliases_for_metric():
-    registry = MetricRegistry()
-    registry.register(DummyMetric, DUMMY_METADATA, aliases=["dummy_alias"])
+    registry = _registry_with_dummy()
 
     assert registry.get_aliases("dummy") == ["dummy_alias"]
     assert registry.get_aliases("dummy_alias") == ["dummy_alias"]
     assert registry.list_aliases() == {"dummy_alias": "dummy"}
+
+
+def test_score_config_validation_accepts_known_alias_and_parameters():
+    metadata = MetricMetadata(
+        **{
+            **DUMMY_METADATA.__dict__,
+            "dependencies": [],
+        }
+    )
+    registry = _registry_with_dummy(metadata)
+
+    validate_score_config(
+        [{"name": "dummy_alias", "threshold": 0.75}],
+        registry=registry,
+    )
+
+
+def test_score_config_validation_reports_actionable_errors():
+    registry = _registry_with_dummy()
+    ref_text_metadata = MetricMetadata(
+        name="needs_ref_text",
+        category=MetricCategory.DEPENDENT,
+        metric_type=MetricType.FLOAT,
+        requires_reference=True,
+        requires_text=True,
+        gpu_compatible=False,
+        auto_install=False,
+        dependencies=[],
+        description="Needs reference audio and text.",
+    )
+    gpu_metadata = MetricMetadata(
+        name="qwen_omni_language",
+        category=MetricCategory.INDEPENDENT,
+        metric_type=MetricType.STRING,
+        requires_reference=False,
+        requires_text=False,
+        gpu_compatible=True,
+        auto_install=False,
+        dependencies=[],
+        description="GPU-required test metric.",
+    )
+    registry.register(DummyMetric, ref_text_metadata)
+    registry.register(DummyMetric, gpu_metadata)
+
+    with pytest.raises(ScoreConfigValidationException) as exc_info:
+        validate_score_config(
+            [
+                {"name": "not_a_metric"},
+                {"name": "needs_ref_text"},
+                {"name": "qwen_omni_language"},
+                {"name": "dummy", "threshlod": 0.5},
+            ],
+            registry=registry,
+            use_gt=False,
+            use_gt_text=False,
+            use_gpu=False,
+        )
+
+    message = str(exc_info.value)
+    assert "unknown metric name 'not_a_metric'" in message
+    assert "requires reference audio" in message
+    assert "requires reference text" in message
+    assert "requires GPU execution" in message
+    assert "unknown parameter(s): threshlod" in message
+
+
+def test_score_config_validation_reports_missing_optional_dependencies():
+    registry = _registry_with_dummy()
+
+    with pytest.raises(ScoreConfigValidationException, match="missing optional"):
+        validate_score_config([{"name": "dummy"}], registry=registry)
 
 
 def test_metric_discovery_describes_metric_without_instantiating_backend():

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -213,6 +213,24 @@ def main():
         )
         logging.warning("Skip DEBUG/INFO messages")
 
+    with open(args.score_config, "r", encoding="utf-8") as f:
+        score_config = yaml.safe_load(f)
+
+    # Validate before any scoring or model setup begins.
+    scorer = VersaScorer()
+    try:
+        from versa.config_validation import validate_score_config
+
+        validate_score_config(
+            score_config,
+            registry=scorer.registry,
+            use_gt=(args.gt is not None and args.gt != "None" and not args.no_match),
+            use_gt_text=(args.text is not None),
+            use_gpu=args.use_gpu,
+        )
+    except ValueError as e:
+        parser.error(str(e))
+
     gen_files = audio_loader_setup(args.pred, args.io)
 
     # find reference file
@@ -244,11 +262,7 @@ def main():
 
     logging.info("The number of utterances = %d" % len(gen_files))
 
-    with open(args.score_config, "r", encoding="utf-8") as f:
-        score_config = yaml.safe_load(f)
-
     # Initialize VersaScorer
-    scorer = VersaScorer()
     score_metadata = {
         config["name"]: scorer.registry.get_metadata(config["name"])
         for config in score_config

--- a/versa/bin/scorer_chunk.py
+++ b/versa/bin/scorer_chunk.py
@@ -16,6 +16,7 @@ import soundfile as sf
 import torch
 import yaml
 from versa.definition import MetricCategory
+from versa.config_validation import validate_score_config
 from versa.scorer_shared import (
     audio_loader_setup,
     list_scoring,
@@ -289,7 +290,8 @@ def _maybe_chunk_filelists(
 
 
 def main():
-    args = get_parser().parse_args()
+    parser = get_parser()
+    args = parser.parse_args()
 
     # In case of using `local` backend, all GPU will be visible to all process.
     if args.use_gpu:
@@ -317,10 +319,27 @@ def main():
         )
         logging.warning("Skip DEBUG/INFO messages")
 
+    # find reference file
+    args.gt = None if args.gt == "None" else args.gt
+
+    with open(args.score_config, "r", encoding="utf-8") as f:
+        score_config = yaml.safe_load(f)
+
+    scorer = VersaScorer()
+    try:
+        validate_score_config(
+            score_config,
+            registry=scorer.registry,
+            use_gt=(args.gt is not None and not args.no_match),
+            use_gt_text=(args.text is not None),
+            use_gpu=args.use_gpu,
+        )
+    except ValueError as e:
+        parser.error(str(e))
+
     gen_files = audio_loader_setup(args.pred, args.io)
 
     # find reference file
-    args.gt = None if args.gt == "None" else args.gt
     if args.gt is not None and not args.no_match:
         gt_files = audio_loader_setup(args.gt, args.io)
     else:
@@ -361,9 +380,6 @@ def main():
     if args.enable_chunking:
         logging.info("The number of items (post-chunk) = %d", len(gen_files))
 
-    with open(args.score_config, "r", encoding="utf-8") as f:
-        score_config = yaml.safe_load(f)
-
     score_modules = load_score_modules(
         score_config,
         use_gt=(True if gt_files is not None else False),
@@ -385,7 +401,6 @@ def main():
     else:
         logging.info("No utterance-level scoring function is provided.")
 
-    scorer = VersaScorer()
     corpus_score_config = []
     for config in score_config:
         metadata = scorer.registry.get_metadata(config["name"])

--- a/versa/config_validation.py
+++ b/versa/config_validation.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Jiatong Shi
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Validation helpers for score configuration files."""
+
+import ast
+import importlib.util
+import inspect
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Dict, Iterable, List, Optional, Set
+
+from versa.definition import MetricRegistry
+from versa.metric_discovery import create_metric_discovery_registry
+
+
+_BASE_CONFIG_KEYS = {"name", "use_gpu"}
+_GPU_REQUIRED_PREFIXES = ("qwen2_audio_", "qwen_omni_")
+_GPU_REQUIRED_METRICS = {"audiobox_aesthetics"}
+
+
+@dataclass(frozen=True)
+class ScoreConfigValidationError:
+    """One score configuration validation issue."""
+
+    index: Optional[int]
+    metric_name: Optional[str]
+    message: str
+
+    def format(self) -> str:
+        location = "score_config"
+        if self.index is not None:
+            location += f"[{self.index}]"
+        if self.metric_name:
+            location += f" ({self.metric_name})"
+        return f"{location}: {self.message}"
+
+
+class ScoreConfigValidationException(ValueError):
+    """Raised when a score configuration cannot be used safely."""
+
+    def __init__(self, errors: Iterable[ScoreConfigValidationError]):
+        self.errors = list(errors)
+        message = "Invalid score configuration:\n" + "\n".join(
+            f"- {error.format()}" for error in self.errors
+        )
+        super().__init__(message)
+
+
+def validate_score_config(
+    score_config: Any,
+    *,
+    registry: Optional[MetricRegistry] = None,
+    use_gt: bool = True,
+    use_gt_text: bool = False,
+    use_gpu: bool = False,
+) -> None:
+    """Validate a YAML score config before metric setup or scoring starts."""
+
+    errors: List[ScoreConfigValidationError] = []
+    if not isinstance(score_config, list) or not score_config:
+        raise ScoreConfigValidationException(
+            [
+                ScoreConfigValidationError(
+                    None,
+                    None,
+                    "expected a non-empty YAML list of metric mappings",
+                )
+            ]
+        )
+
+    registry = registry or create_metric_discovery_registry()
+    discovery_registry: Optional[MetricRegistry] = None
+
+    for index, config in enumerate(score_config):
+        if not isinstance(config, dict):
+            errors.append(
+                ScoreConfigValidationError(
+                    index,
+                    None,
+                    "expected a mapping with at least a 'name' key",
+                )
+            )
+            continue
+
+        metric_name = config.get("name")
+        if not isinstance(metric_name, str) or not metric_name:
+            errors.append(
+                ScoreConfigValidationError(
+                    index,
+                    None,
+                    "missing required metric name; add 'name: <metric>'",
+                )
+            )
+            continue
+
+        metadata = registry.get_metadata(metric_name)
+        metric_class = registry.get_metric(metric_name)
+        if metadata is None:
+            discovery_registry = discovery_registry or create_metric_discovery_registry()
+            metadata = discovery_registry.get_metadata(metric_name)
+            metric_class = discovery_registry.get_metric(metric_name)
+        if metadata is None or metric_class is None:
+            errors.append(
+                ScoreConfigValidationError(
+                    index,
+                    metric_name,
+                    _unknown_metric_message(registry, metric_name),
+                )
+            )
+            continue
+
+        if metadata.requires_reference and not use_gt:
+            errors.append(
+                ScoreConfigValidationError(
+                    index,
+                    metric_name,
+                    "requires reference audio; provide --gt or remove this metric",
+                )
+            )
+
+        if metadata.requires_text and not use_gt_text:
+            errors.append(
+                ScoreConfigValidationError(
+                    index,
+                    metric_name,
+                    "requires reference text; provide --text or remove this metric",
+                )
+            )
+
+        if _requires_gpu_flag(metadata.name) and not use_gpu:
+            errors.append(
+                ScoreConfigValidationError(
+                    index,
+                    metric_name,
+                    "requires GPU execution; rerun with --use_gpu or remove this metric",
+                )
+            )
+
+        missing_dependencies = [
+            dependency
+            for dependency in metadata.dependencies
+            if not _dependency_available(dependency)
+        ]
+        if missing_dependencies:
+            errors.append(
+                ScoreConfigValidationError(
+                    index,
+                    metric_name,
+                    "missing optional dependencies: "
+                    + ", ".join(missing_dependencies)
+                    + ". Install them or remove this metric from the config",
+                )
+            )
+
+        allowed_keys = (
+            None
+            if metric_class.__name__ == "_DiscoveredMetric"
+            else _allowed_config_keys(metric_class)
+        )
+        if allowed_keys:
+            unknown_keys = sorted(set(config) - allowed_keys)
+            if unknown_keys:
+                errors.append(
+                    ScoreConfigValidationError(
+                        index,
+                        metric_name,
+                        "unknown parameter(s): "
+                        + ", ".join(unknown_keys)
+                        + ". Allowed parameters: "
+                        + ", ".join(sorted(allowed_keys)),
+                    )
+                )
+
+    if errors:
+        raise ScoreConfigValidationException(errors)
+
+
+def _unknown_metric_message(registry: MetricRegistry, metric_name: str) -> str:
+    message = f"unknown metric name '{metric_name}'"
+    suggestions = _suggest_metric_names(registry, metric_name)
+    if suggestions:
+        message += "; did you mean " + ", ".join(suggestions) + "?"
+    return message
+
+
+def _suggest_metric_names(registry: MetricRegistry, metric_name: str) -> List[str]:
+    query = metric_name.lower()
+    names = set(registry.list_metrics()) | set(registry.list_aliases())
+    return sorted(name for name in names if query in name.lower())[:5]
+
+
+def _requires_gpu_flag(metric_name: str) -> bool:
+    return metric_name in _GPU_REQUIRED_METRICS or metric_name.startswith(
+        _GPU_REQUIRED_PREFIXES
+    )
+
+
+@lru_cache(maxsize=None)
+def _dependency_available(dependency: str) -> bool:
+    return importlib.util.find_spec(dependency) is not None
+
+
+@lru_cache(maxsize=None)
+def _allowed_config_keys(metric_class: type) -> Optional[frozenset]:
+    keys: Set[str] = set(_BASE_CONFIG_KEYS)
+    found_source = False
+
+    for cls in inspect.getmro(metric_class):
+        if cls is object:
+            continue
+        try:
+            source = inspect.getsource(cls)
+        except (OSError, TypeError):
+            continue
+
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+
+        found_source = True
+        for node in ast.walk(tree):
+            key = _self_config_get_key(node) or _self_config_subscript_key(node)
+            if key:
+                keys.add(key)
+
+    return frozenset(keys) if found_source else None
+
+
+def _self_config_get_key(node: ast.AST) -> Optional[str]:
+    if not isinstance(node, ast.Call):
+        return None
+    if not isinstance(node.func, ast.Attribute) or node.func.attr != "get":
+        return None
+    if not _is_self_config(node.func.value):
+        return None
+    if not node.args:
+        return None
+    first_arg = node.args[0]
+    if isinstance(first_arg, ast.Constant) and isinstance(first_arg.value, str):
+        return first_arg.value
+    return None
+
+
+def _self_config_subscript_key(node: ast.AST) -> Optional[str]:
+    if not isinstance(node, ast.Subscript) or not _is_self_config(node.value):
+        return None
+    slice_node = node.slice
+    if isinstance(slice_node, ast.Constant) and isinstance(slice_node.value, str):
+        return slice_node.value
+    return None
+
+
+def _is_self_config(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Attribute)
+        and node.attr == "config"
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "self"
+    )

--- a/versa/config_validation.py
+++ b/versa/config_validation.py
@@ -15,7 +15,6 @@ from typing import Any, Dict, Iterable, List, Optional, Set
 from versa.definition import MetricRegistry
 from versa.metric_discovery import create_metric_discovery_registry
 
-
 _BASE_CONFIG_KEYS = {"name", "use_gpu"}
 _GPU_REQUIRED_PREFIXES = ("qwen2_audio_", "qwen_omni_")
 _GPU_REQUIRED_METRICS = {"audiobox_aesthetics"}
@@ -99,7 +98,9 @@ def validate_score_config(
         metadata = registry.get_metadata(metric_name)
         metric_class = registry.get_metric(metric_name)
         if metadata is None:
-            discovery_registry = discovery_registry or create_metric_discovery_registry()
+            discovery_registry = (
+                discovery_registry or create_metric_discovery_registry()
+            )
             metadata = discovery_registry.get_metadata(metric_name)
             metric_class = discovery_registry.get_metric(metric_name)
         if metadata is None or metric_class is None:


### PR DESCRIPTION
## Summary

Adds a preflight validator for YAML score configs so users get clear, actionable errors before audio loading, metric setup, or scoring begins.

The validator now catches unknown metric names, missing reference audio/text, GPU-required metrics without --use_gpu, missing optional dependencies, and unknown top-level metric parameters.

## Validation

- .codex-test-venv/bin/python -m pytest test/test_metrics/test_definition.py -q
- .codex-test-venv/bin/python -m py_compile versa/config_validation.py versa/bin/scorer.py versa/bin/scorer_chunk.py