### PR TITLE
Improve reporting import and report generation

### DIFF
--- a/test/test_reporting.py
+++ b/test/test_reporting.py
@@ -1,5 +1,9 @@
 import csv
+import subprocess
+import sys
 
+from versa.definition import MetricCategory, MetricMetadata, MetricRegistry, MetricType
+from versa.bin.scorer import _write_report
 from versa.reporting import (
     analyze_records,
     metric_category,
@@ -72,3 +76,62 @@ def test_report_exports(tmp_path):
 def test_metric_category_strips_model_prefixes():
     assert metric_category("arecho_pesq") == "speech_enhancement"
     assert metric_category("custom_wer") == "asr_wer_cer"
+
+
+def test_reporting_import_is_lightweight():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from versa.reporting import analyze_records; print(analyze_records)",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+    assert "analyze_records" in result.stdout
+
+
+def test_reporting_uses_registry_alias_metadata():
+    registry = MetricRegistry()
+    registry.register(
+        object,
+        MetricMetadata(
+            name="pesq",
+            category=MetricCategory.DEPENDENT,
+            metric_type=MetricType.FLOAT,
+            requires_reference=True,
+            requires_text=False,
+            gpu_compatible=False,
+            auto_install=True,
+            dependencies=["pesq"],
+            description="PESQ",
+        ),
+        aliases=["custom_pesq_alias"],
+    )
+
+    assert (
+        metric_category("custom_pesq_alias", registry=registry) == "speech_enhancement"
+    )
+    assert (
+        metric_category("experiment_custom_pesq_alias", registry=registry)
+        == "speech_enhancement"
+    )
+
+
+def test_scorer_report_writer_exports_html(tmp_path):
+    registry = MetricRegistry()
+    report_path = tmp_path / "score_report.html"
+
+    _write_report(
+        [{"key": "a", "pesq": 2.0}, {"key": "b", "pesq": 3.0}],
+        str(report_path),
+        report_format="auto",
+        group_by=None,
+        outlier_limit=3,
+        registry=registry,
+    )
+
+    assert "VERSA Results Report" in report_path.read_text(encoding="utf-8")

--- a/versa/__init__.py
+++ b/versa/__init__.py
@@ -1,298 +1,32 @@
-import importlib
-import logging
+"""VERSA package initialization.
+
+Optional metric modules are loaded lazily so lightweight helpers such as
+reporting and aggregation do not import model-backed dependencies.
+"""
+
 import os
-import sys
 from pathlib import Path
 from importlib.metadata import PackageNotFoundError, version
+
+from versa.metric_registry import load_metric_symbol, metric_symbol_names
 
 try:
     __version__ = version("versa-speech-audio-toolkit")
 except PackageNotFoundError:
     __version__ = "1.0.0"
 
-logger = logging.getLogger(__name__)
-
 os.environ.setdefault(
     "NUMBA_CACHE_DIR", str(Path.cwd() / "versa_cache" / "numba_cache")
 )
 
-_SKIP_OPTIONAL_METRIC_IMPORTS = any(
-    flag in sys.argv
-    for flag in ("--list-metrics", "--describe-metric", "--recommend-config")
-)
-_SKIP_OPTIONAL_METRIC_IMPORTS = _SKIP_OPTIONAL_METRIC_IMPORTS or any(
-    Path(arg).name
-    in {"versa-visualize", "versa-aggregate", "visualize.py", "aggregate_results.py"}
-    or arg.endswith("versa.bin.visualize")
-    or arg.endswith("versa.bin.aggregate_results")
-    for arg in sys.argv
-)
+
+def __getattr__(name):
+    if name in metric_symbol_names():
+        symbol = load_metric_symbol(name)
+        globals()[name] = symbol
+        return symbol
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-def _optional_metric_import(module_name, names, install_hint=None):
-    """Import optional metric symbols without making package import fail."""
-    if _SKIP_OPTIONAL_METRIC_IMPORTS:
-        return
-
-    try:
-        module = importlib.import_module(module_name)
-    except ImportError:
-        if install_hint:
-            logger.info(install_hint)
-        else:
-            logger.info("Optional metric module %s is not available", module_name)
-        return
-    except RuntimeError:
-        logger.info("Issues detected in %s; please check the environment.", module_name)
-        return
-
-    for name in names:
-        globals()[name] = getattr(module, name)
-
-
-_optional_metric_import(
-    "versa.sequence_metrics.mcd_f0",
-    ("McdF0Metric", "register_mcd_f0_metric"),
-)
-# from versa.sequence_metrics.signal_metric import SignalMetric, register_signal_metric
-_optional_metric_import(
-    "versa.sequence_metrics.warpq",
-    ("WarpqMetric", "register_warpq_metric"),
-)
-
-_optional_metric_import(
-    "versa.utterance_metrics.discrete_speech",
-    ("DiscreteSpeechMetric", "register_discrete_speech_metric"),
-    (
-        "Please pip install "
-        "git+https://github.com/ftshijt/DiscreteSpeechMetrics.git and retry"
-    ),
-)
-
-_optional_metric_import(
-    "versa.utterance_metrics.pseudo_mos",
-    ("PseudoMosMetric", "register_pseudo_mos_metric"),
-)
-
-_optional_metric_import(
-    "versa.utterance_metrics.pesq_score",
-    ("PesqMetric", "register_pesq_metric"),
-    "Please install pesq with `pip install pesq` and retry",
-)
-
-# try:
-#     from versa.utterance_metrics.stoi import StoiMetric, register_stoi_metric
-# except ImportError:
-#     logging.info("Please install pystoi with `pip install pystoi` and retry")
-_optional_metric_import(
-    "versa.utterance_metrics.stoi",
-    ("StoiMetric", "EstoiMetric", "register_stoi_metric"),
-    "Please install pystoi with `pip install pystoi` and retry",
-)
-
-_optional_metric_import(
-    "versa.utterance_metrics.speaker",
-    ("SpeakerMetric", "register_speaker_metric"),
-)
-
-_optional_metric_import(
-    "versa.utterance_metrics.singer",
-    ("SingerMetric", "register_singer_metric"),
-    "Please install singer_identity following tools/install_ssl-singer-identity.sh",
-)
-
-_optional_metric_import(
-    "versa.utterance_metrics.visqol_score",
-    ("VisqolMetric", "register_visqol_metric"),
-    "Please install visqol following https://github.com/google/visqol and retry",
-)
-
-_optional_metric_import(
-    "versa.corpus_metrics.espnet_wer",
-    ("EspnetWerMetric", "register_espnet_wer_metric"),
-)
-_optional_metric_import(
-    "versa.corpus_metrics.clap_score",
-    ("ClapScoreMetric", "register_clap_score_metric"),
-    "Please install frechet-audio-distance following tools/install_clap_score.sh",
-)
-_optional_metric_import(
-    "versa.corpus_metrics.fad",
-    ("FadMetric", "register_fad_metric"),
-    "Please install FADTK following tools/install_fadtk.sh",
-)
-_optional_metric_import(
-    "versa.corpus_metrics.individual_fad",
-    ("IndividualFadMetric", "register_individual_fad_metric"),
-    "Please install FADTK following tools/install_fadtk.sh",
-)
-_optional_metric_import(
-    "versa.corpus_metrics.kid",
-    ("KidMetric", "register_kid_metric"),
-    "Please install FADTK following tools/install_fadtk.sh",
-)
-_optional_metric_import(
-    "versa.corpus_metrics.owsm_wer",
-    ("OwsmWerMetric", "register_owsm_wer_metric"),
-)
-_optional_metric_import(
-    "versa.corpus_metrics.whisper_wer",
-    ("WhisperWerMetric", "register_whisper_wer_metric"),
-)
-_optional_metric_import(
-    "versa.corpus_metrics.fwhisper_wer",
-    ("FasterWhisperWerMetric", "register_fwhisper_wer_metric"),
-    "Please install faster-whisper following tools/install_fwhisper.sh",
-)
-_optional_metric_import(
-    "versa.corpus_metrics.nemo_wer",
-    ("NemoWerMetric", "register_nemo_wer_metric"),
-    "Please install NeMo following tools/install_nemo.sh",
-)
-_optional_metric_import(
-    "versa.corpus_metrics.hubert_wer",
-    ("HubertWerMetric", "register_hubert_wer_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.asr_matching",
-    ("ASRMatchMetric", "register_asr_match_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.audiobox_aesthetics_score",
-    ("AudioBoxAestheticsMetric", "register_audiobox_aesthetics_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.asvspoof_score",
-    ("ASVSpoofMetric", "register_asvspoof_metric"),
-    "Please install AASIST following tools/install_asvspoof.sh",
-)
-_optional_metric_import(
-    "versa.utterance_metrics.emo_similarity",
-    ("Emo2vecMetric", "register_emo2vec_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.emo_vad",
-    ("EmoVadMetric", "register_emo_vad_metric"),
-    "Please install transformers and retry",
-)
-_optional_metric_import(
-    "versa.utterance_metrics.nomad",
-    ("NomadMetric", "register_nomad_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.noresqa",
-    ("NoresqaMetric", "register_noresqa_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.owsm_lid",
-    ("OwsmLidMetric", "register_owsm_lid_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.log_wmse",
-    ("LogWmseMetric", "register_log_wmse_metric"),
-    "Please install torch-log-wmse and retry",
-)
-_optional_metric_import(
-    "versa.utterance_metrics.universa",
-    ("UniversaMetric", "register_universa_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.arecho",
-    ("ArechoMetric", "register_arecho_metric"),
-)
-
-# from versa.utterance_metrics.pysepm import PysepmMetric, register_pysepm_metric
-_optional_metric_import(
-    "versa.utterance_metrics.pysepm",
-    ("PysepmMetric", "register_pysepm_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.qwen2_audio",
-    ("Qwen2AudioMetric", "register_qwen2_audio_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.qwen_omni",
-    ("QwenOmniMetric", "register_qwen_omni_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.scoreq",
-    (
-        "ScoreqMetric",
-        "ScoreqNrMetric",
-        "ScoreqRefMetric",
-        "register_scoreq_metric",
-    ),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.se_snr",
-    ("SeSnrMetric", "register_se_snr_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.sheet_ssqa",
-    ("SheetSsqaMetric", "register_sheet_ssqa_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.speaking_rate",
-    ("SpeakingRateMetric", "register_speaking_rate_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.squim",
-    ("SquimMetric", "SquimRefMetric", "SquimNoRefMetric", "register_squim_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.srmr",
-    ("SRMRMetric", "register_srmr_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.chroma_alignment",
-    ("ChromaAlignmentMetric", "register_chroma_alignment_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.dpam_distance",
-    ("DpamDistanceMetric", "register_dpam_distance_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.cdpam_distance",
-    ("CdpamDistanceMetric", "register_cdpam_distance_metric"),
-)
-
-_optional_metric_import(
-    "versa.utterance_metrics.vqscore",
-    ("VqscoreMetric", "register_vqscore_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.multigauss",
-    ("MultiGaussMetric", "register_multigauss_metric"),
-    "Please install MultiGauss following tools/install_multigauss.sh",
-)
-_optional_metric_import(
-    "versa.utterance_metrics.songeval",
-    ("SongEvalMetric", "register_songeval_metric"),
-    "Please install SongEval dependencies following tools/install_songeval.sh",
-)
-_optional_metric_import(
-    "versa.utterance_metrics.vad",
-    ("VadMetric", "register_vad_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.nisqa",
-    ("NisqaMetric", "register_nisqa_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.pam",
-    ("PamMetric", "register_pam_metric"),
-)
-_optional_metric_import(
-    "versa.sequence_metrics.signal_metric",
-    ("SignalMetric", "register_signal_metric"),
-)
-_optional_metric_import(
-    "versa.utterance_metrics.sigmos",
-    ("SigmosMetric", "register_sigmos_metric"),
-    "Please install SigMOS dependencies and retry",
-)
-_optional_metric_import(
-    "versa.utterance_metrics.wvmos",
-    ("WvmosMetric", "register_wvmos_metric"),
-    "Please install WVMOS following tools/install_wvmos.sh",
-)
+def __dir__():
+    return sorted(set(globals()) | set(metric_symbol_names()))

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -94,6 +94,33 @@ def get_parser() -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--report",
+        type=str,
+        default=None,
+        help=(
+            "Optional report path generated from utterance-level scores after "
+            "scoring. Format is inferred from extension unless --report-format "
+            "is set."
+        ),
+    )
+    parser.add_argument(
+        "--report-format",
+        choices=["auto", "html", "csv", "md"],
+        default="auto",
+        help="Report format for --report.",
+    )
+    parser.add_argument(
+        "--report-group-by",
+        default=None,
+        help="Optional scored record field used for per-metric report rankings.",
+    )
+    parser.add_argument(
+        "--report-outlier-limit",
+        type=int,
+        default=3,
+        help="Maximum outlier examples to keep per metric in --report.",
+    )
+    parser.add_argument(
         "--list-metrics",
         action="store_true",
         help="List registered metrics and exit.",
@@ -270,6 +297,7 @@ def main():
         )
     ]
 
+    score_info = []
     if args.scoring_mode == "metric":
         score_info = scorer.score_utterances_by_metric(
             gen_files,
@@ -342,6 +370,63 @@ def main():
     # Ensure at least one scoring function is provided
     if utterance_metric_count == 0 and len(corpus_suite.metrics) == 0:
         raise ValueError("No scoring function is provided")
+
+    if args.report:
+        if not score_info:
+            raise ValueError("--report requires at least one utterance-level score")
+        _write_report(
+            score_info,
+            args.report,
+            report_format=args.report_format,
+            group_by=args.report_group_by,
+            outlier_limit=args.report_outlier_limit,
+            registry=scorer.registry,
+        )
+
+
+def _write_report(
+    score_info,
+    report_path,
+    *,
+    report_format,
+    group_by,
+    outlier_limit,
+    registry,
+):
+    from pathlib import Path
+
+    from versa.reporting import (
+        analyze_records,
+        write_csv_report,
+        write_html_report,
+        write_markdown_report,
+    )
+
+    output_path = Path(report_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if report_format == "auto":
+        report_format = {
+            ".html": "html",
+            ".htm": "html",
+            ".csv": "csv",
+            ".md": "md",
+            ".markdown": "md",
+        }.get(output_path.suffix.lower(), "html")
+
+    analysis = analyze_records(
+        score_info,
+        group_by=group_by,
+        outlier_limit=outlier_limit,
+        registry=registry,
+    )
+    if report_format == "html":
+        write_html_report(analysis, report_path)
+    elif report_format == "csv":
+        write_csv_report(analysis, report_path)
+    else:
+        write_markdown_report(analysis, report_path)
+
+    logging.info("Wrote %s report to %s", report_format, report_path)
 
 
 if __name__ == "__main__":

--- a/versa/bin/visualize.py
+++ b/versa/bin/visualize.py
@@ -6,6 +6,7 @@ import argparse
 import os
 from pathlib import Path
 
+from versa.metric_discovery import create_metric_discovery_registry
 from versa.reporting import (
     analyze_records,
     read_result_records,
@@ -64,10 +65,12 @@ def main() -> None:
     args = parser.parse_args()
 
     records = read_result_records(args.input)
+    registry = create_metric_discovery_registry(include_runtime_imports=False)
     analysis = analyze_records(
         records,
         group_by=args.group_by,
         outlier_limit=args.outlier_limit,
+        registry=registry,
     )
 
     output_path = Path(args.out)

--- a/versa/metric_discovery.py
+++ b/versa/metric_discovery.py
@@ -116,23 +116,17 @@ _TASK_ALIASES = {
 }
 
 
-def create_metric_discovery_registry() -> MetricRegistry:
+def create_metric_discovery_registry(
+    *, include_runtime_imports: bool = False
+) -> MetricRegistry:
     """Create the registry used by discovery commands."""
-    with _quiet_metric_imports():
-        import versa as versa_package
+    if include_runtime_imports:
+        with _quiet_metric_imports():
+            from versa.metric_registry import create_populated_registry
 
+            registry = create_populated_registry(logger=logging.getLogger(__name__))
+    else:
         registry = MetricRegistry()
-        for name in dir(versa_package):
-            if not name.startswith("register_") or not name.endswith("_metric"):
-                continue
-            register_fn = getattr(versa_package, name)
-            if callable(register_fn):
-                try:
-                    register_fn(registry)
-                except Exception as e:
-                    logging.getLogger(__name__).debug(
-                        "Failed to register metric via %s: %s", name, e
-                    )
     _add_source_discovered_metrics(registry)
     return registry
 

--- a/versa/metric_registry.py
+++ b/versa/metric_registry.py
@@ -1,0 +1,376 @@
+"""Helpers for loading optional metric modules."""
+
+import importlib
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Optional
+
+from versa.definition import MetricRegistry
+
+
+@dataclass(frozen=True)
+class MetricModuleSpec:
+    module_name: str
+    symbols: tuple
+    install_hint: Optional[str] = None
+
+
+METRIC_MODULES = (
+    MetricModuleSpec(
+        "versa.sequence_metrics.mcd_f0",
+        ("McdF0Metric", "register_mcd_f0_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.sequence_metrics.warpq",
+        ("WarpqMetric", "register_warpq_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.discrete_speech",
+        ("DiscreteSpeechMetric", "register_discrete_speech_metric"),
+        (
+            "Please pip install "
+            "git+https://github.com/ftshijt/DiscreteSpeechMetrics.git and retry"
+        ),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.pseudo_mos",
+        ("PseudoMosMetric", "register_pseudo_mos_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.pesq_score",
+        ("PesqMetric", "register_pesq_metric"),
+        "Please install pesq with `pip install pesq` and retry",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.stoi",
+        ("StoiMetric", "EstoiMetric", "register_stoi_metric"),
+        "Please install pystoi with `pip install pystoi` and retry",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.speaker",
+        ("SpeakerMetric", "register_speaker_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.singer",
+        ("SingerMetric", "register_singer_metric"),
+        "Please install singer_identity following tools/install_ssl-singer-identity.sh",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.visqol_score",
+        ("VisqolMetric", "register_visqol_metric"),
+        "Please install visqol following https://github.com/google/visqol and retry",
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.espnet_wer",
+        ("EspnetWerMetric", "register_espnet_wer_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.clap_score",
+        ("ClapScoreMetric", "register_clap_score_metric"),
+        "Please install frechet-audio-distance following tools/install_clap_score.sh",
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.fad",
+        ("FadMetric", "register_fad_metric"),
+        "Please install FADTK following tools/install_fadtk.sh",
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.individual_fad",
+        ("IndividualFadMetric", "register_individual_fad_metric"),
+        "Please install FADTK following tools/install_fadtk.sh",
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.kid",
+        ("KidMetric", "register_kid_metric"),
+        "Please install FADTK following tools/install_fadtk.sh",
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.owsm_wer",
+        ("OwsmWerMetric", "register_owsm_wer_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.whisper_wer",
+        ("WhisperWerMetric", "register_whisper_wer_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.fwhisper_wer",
+        ("FasterWhisperWerMetric", "register_fwhisper_wer_metric"),
+        "Please install faster-whisper following tools/install_fwhisper.sh",
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.nemo_wer",
+        ("NemoWerMetric", "register_nemo_wer_metric"),
+        "Please install NeMo following tools/install_nemo.sh",
+    ),
+    MetricModuleSpec(
+        "versa.corpus_metrics.hubert_wer",
+        ("HubertWerMetric", "register_hubert_wer_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.asr_matching",
+        ("ASRMatchMetric", "register_asr_match_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.audiobox_aesthetics_score",
+        ("AudioBoxAestheticsMetric", "register_audiobox_aesthetics_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.asvspoof_score",
+        ("ASVSpoofMetric", "register_asvspoof_metric"),
+        "Please install AASIST following tools/install_asvspoof.sh",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.emo_similarity",
+        ("Emo2vecMetric", "register_emo2vec_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.emo_vad",
+        ("EmoVadMetric", "register_emo_vad_metric"),
+        "Please install transformers and retry",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.nomad",
+        ("NomadMetric", "register_nomad_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.noresqa",
+        ("NoresqaMetric", "register_noresqa_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.owsm_lid",
+        ("OwsmLidMetric", "register_owsm_lid_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.log_wmse",
+        ("LogWmseMetric", "register_log_wmse_metric"),
+        "Please install torch-log-wmse and retry",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.universa",
+        ("UniversaMetric", "register_universa_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.arecho",
+        ("ArechoMetric", "register_arecho_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.pysepm",
+        ("PysepmMetric", "register_pysepm_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.qwen2_audio",
+        ("Qwen2AudioMetric", "register_qwen2_audio_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.qwen_omni",
+        ("QwenOmniMetric", "register_qwen_omni_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.scoreq",
+        (
+            "ScoreqMetric",
+            "ScoreqNrMetric",
+            "ScoreqRefMetric",
+            "register_scoreq_metric",
+        ),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.se_snr",
+        ("SeSnrMetric", "register_se_snr_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.sheet_ssqa",
+        ("SheetSsqaMetric", "register_sheet_ssqa_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.speaking_rate",
+        ("SpeakingRateMetric", "register_speaking_rate_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.squim",
+        ("SquimMetric", "SquimRefMetric", "SquimNoRefMetric", "register_squim_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.srmr",
+        ("SRMRMetric", "register_srmr_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.chroma_alignment",
+        ("ChromaAlignmentMetric", "register_chroma_alignment_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.dpam_distance",
+        ("DpamDistanceMetric", "register_dpam_distance_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.cdpam_distance",
+        ("CdpamDistanceMetric", "register_cdpam_distance_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.vqscore",
+        ("VqscoreMetric", "register_vqscore_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.multigauss",
+        ("MultiGaussMetric", "register_multigauss_metric"),
+        "Please install MultiGauss following tools/install_multigauss.sh",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.songeval",
+        ("SongEvalMetric", "register_songeval_metric"),
+        "Please install SongEval dependencies following tools/install_songeval.sh",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.vad",
+        ("VadMetric", "register_vad_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.nisqa",
+        ("NisqaMetric", "register_nisqa_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.pam",
+        ("PamMetric", "register_pam_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.sequence_metrics.signal_metric",
+        ("SignalMetric", "register_signal_metric"),
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.sigmos",
+        ("SigmosMetric", "register_sigmos_metric"),
+        "Please install SigMOS dependencies and retry",
+    ),
+    MetricModuleSpec(
+        "versa.utterance_metrics.wvmos",
+        ("WvmosMetric", "register_wvmos_metric"),
+        "Please install WVMOS following tools/install_wvmos.sh",
+    ),
+)
+
+_SYMBOL_TO_SPEC = {symbol: spec for spec in METRIC_MODULES for symbol in spec.symbols}
+
+
+def metric_symbol_names() -> Iterable[str]:
+    """Return metric symbols that can be loaded lazily from optional modules."""
+    return _SYMBOL_TO_SPEC.keys()
+
+
+def load_metric_symbol(symbol: str, logger: Optional[logging.Logger] = None) -> Any:
+    """Load one optional metric symbol by name."""
+    spec = _SYMBOL_TO_SPEC.get(symbol)
+    if spec is None:
+        raise AttributeError(symbol)
+    module = importlib.import_module(spec.module_name)
+    return getattr(module, symbol)
+
+
+def load_metric_symbols(
+    target_globals: Optional[Dict[str, Any]] = None,
+    logger: Optional[logging.Logger] = None,
+) -> Dict[str, Any]:
+    """Import all optional metric modules and return their exported symbols."""
+    loaded: Dict[str, Any] = {}
+    for spec in METRIC_MODULES:
+        module = _try_import_metric_module(spec, logger=logger)
+        if module is None:
+            continue
+        for symbol in spec.symbols:
+            loaded[symbol] = getattr(module, symbol)
+    if target_globals is not None:
+        target_globals.update(loaded)
+    return loaded
+
+
+def create_populated_registry(
+    logger: Optional[logging.Logger] = None,
+) -> MetricRegistry:
+    """Create a registry populated by all importable metric modules."""
+    registry = MetricRegistry()
+    for name, symbol in load_metric_symbols(logger=logger).items():
+        if not name.startswith("register_") or not name.endswith("_metric"):
+            continue
+        if callable(symbol):
+            try:
+                symbol(registry)
+            except Exception as exc:
+                (logger or logging.getLogger(__name__)).warning(
+                    "Failed to register metric via %s: %s", name, exc
+                )
+    return registry
+
+
+def register_metric_for_config(
+    registry: MetricRegistry,
+    metric_name: str,
+    logger: Optional[logging.Logger] = None,
+) -> None:
+    """Import the best matching runtime module for one configured metric."""
+    if _has_concrete_metric(registry, metric_name):
+        return
+
+    log = logger or logging.getLogger(__name__)
+    for spec in sorted(
+        METRIC_MODULES, key=lambda item: _metric_spec_score(metric_name, item)
+    ):
+        module = _try_import_metric_module(spec, logger=log)
+        if module is None:
+            continue
+        for symbol in spec.symbols:
+            if not symbol.startswith("register_") or not symbol.endswith("_metric"):
+                continue
+            register_fn = getattr(module, symbol)
+            try:
+                register_fn(registry)
+            except Exception as exc:
+                log.warning("Failed to register metric via %s: %s", symbol, exc)
+        if _has_concrete_metric(registry, metric_name):
+            return
+
+
+def _has_concrete_metric(registry: MetricRegistry, metric_name: str) -> bool:
+    metric_class = registry.get_metric(metric_name)
+    if metric_class is None:
+        return False
+    return hasattr(metric_class, "compute") and hasattr(metric_class, "get_metadata")
+
+
+def _metric_spec_score(metric_name: str, spec: MetricModuleSpec) -> int:
+    query = _normalize_metric_name(metric_name)
+    module_tail = _normalize_metric_name(spec.module_name.rsplit(".", 1)[-1])
+    symbol_tails = [
+        _normalize_metric_name(_strip_symbol_affixes(symbol)) for symbol in spec.symbols
+    ]
+    if query == module_tail or module_tail in query or query in module_tail:
+        return 0
+    if any(query == tail or tail in query or query in tail for tail in symbol_tails):
+        return 0
+    return 1
+
+
+def _normalize_metric_name(value: str) -> str:
+    return "".join(character for character in value.lower() if character.isalnum())
+
+
+def _strip_symbol_affixes(symbol: str) -> str:
+    if symbol.startswith("register_"):
+        symbol = symbol[len("register_") :]
+    if symbol.endswith("_metric"):
+        symbol = symbol[: -len("_metric")]
+    return symbol
+
+
+def _try_import_metric_module(
+    spec: MetricModuleSpec, logger: Optional[logging.Logger] = None
+) -> Optional[Any]:
+    log = logger or logging.getLogger(__name__)
+    try:
+        return importlib.import_module(spec.module_name)
+    except ImportError:
+        if spec.install_hint:
+            log.info(spec.install_hint)
+        else:
+            log.info("Optional metric module %s is not available", spec.module_name)
+    except Exception as exc:
+        log.info("Issues detected in %s: %s", spec.module_name, exc)
+    return None

--- a/versa/reporting.py
+++ b/versa/reporting.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from versa.definition import MetricRegistry
+
 IGNORED_FIELDS = {"key", "_source_file"}
 
 
@@ -156,6 +158,7 @@ def analyze_records(
     *,
     group_by: Optional[str] = None,
     outlier_limit: int = 3,
+    registry: Optional[MetricRegistry] = None,
 ) -> Dict[str, Any]:
     """Compute report-ready summaries from result records."""
     if not records:
@@ -163,7 +166,9 @@ def analyze_records(
 
     metrics = discover_numeric_metrics(records)
     metric_summaries = [
-        summarize_metric(metric, records, outlier_limit=outlier_limit)
+        summarize_metric(
+            metric, records, outlier_limit=outlier_limit, registry=registry
+        )
         for metric in sorted(metrics)
     ]
     categories: Dict[str, List[MetricSummary]] = defaultdict(list)
@@ -172,7 +177,7 @@ def analyze_records(
 
     groups = {}
     if group_by:
-        groups = summarize_groups(records, metrics, group_by)
+        groups = summarize_groups(records, metrics, group_by, registry=registry)
 
     return {
         "records": records,
@@ -197,7 +202,11 @@ def discover_numeric_metrics(records: Sequence[Dict[str, Any]]) -> List[str]:
 
 
 def summarize_metric(
-    metric: str, records: Sequence[Dict[str, Any]], *, outlier_limit: int = 3
+    metric: str,
+    records: Sequence[Dict[str, Any]],
+    *,
+    outlier_limit: int = 3,
+    registry: Optional[MetricRegistry] = None,
 ) -> MetricSummary:
     values: List[Tuple[str, float]] = []
     missing = 0
@@ -223,7 +232,7 @@ def summarize_metric(
     ci_delta = 1.96 * stderr
     minimum = min(numeric) if numeric else 0.0
     maximum = max(numeric) if numeric else 0.0
-    higher_is_better = metric_direction(metric)
+    higher_is_better = metric_direction(metric, registry=registry)
 
     if values and higher_is_better is False:
         best_key, best_value = min(values, key=lambda item: item[1])
@@ -247,7 +256,7 @@ def summarize_metric(
 
     return MetricSummary(
         name=metric,
-        category=metric_category(metric),
+        category=metric_category(metric, registry=registry),
         count=count,
         missing=missing,
         invalid=invalid,
@@ -269,7 +278,10 @@ def summarize_metric(
 
 
 def summarize_groups(
-    records: Sequence[Dict[str, Any]], metrics: Sequence[str], group_by: str
+    records: Sequence[Dict[str, Any]],
+    metrics: Sequence[str],
+    group_by: str,
+    registry: Optional[MetricRegistry] = None,
 ) -> Dict[str, Any]:
     grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
     for record in records:
@@ -277,10 +289,12 @@ def summarize_groups(
 
     metric_rankings = {}
     for metric in metrics:
-        direction = metric_direction(metric)
+        direction = metric_direction(metric, registry=registry)
         rows = []
         for group, group_records in grouped.items():
-            summary = summarize_metric(metric, group_records, outlier_limit=0)
+            summary = summarize_metric(
+                metric, group_records, outlier_limit=0, registry=registry
+            )
             if summary.count:
                 rows.append(
                     {
@@ -463,8 +477,11 @@ svg text {{ font-family: inherit; fill: var(--muted); font-size: 11px; }}
         handle.write(document)
 
 
-def metric_category(metric: str) -> str:
-    normalized = _strip_prefix(metric).lower()
+def metric_category(metric: str, registry: Optional[MetricRegistry] = None) -> str:
+    metadata = _metadata_for_metric(metric, registry)
+    if metadata and metadata.category.value in {"non_match", "distributional"}:
+        return metadata.category.value
+    normalized = _strip_prefix(metadata.name if metadata else metric).lower()
     for category, names in METRIC_CATEGORIES.items():
         if normalized in {name.lower() for name in names}:
             return category
@@ -483,8 +500,11 @@ def metric_category(metric: str) -> str:
     return "other"
 
 
-def metric_direction(metric: str) -> Optional[bool]:
-    normalized = _strip_prefix(metric).lower()
+def metric_direction(
+    metric: str, registry: Optional[MetricRegistry] = None
+) -> Optional[bool]:
+    metadata = _metadata_for_metric(metric, registry)
+    normalized = _strip_prefix(metadata.name if metadata else metric).lower()
     if any(token in normalized for token in ["wer", "cer", "error", "rmse", "mcd"]):
         return False
     if "distance" in normalized and "token_distance" not in normalized:
@@ -510,6 +530,28 @@ def metric_direction(metric: str) -> Optional[bool]:
     ):
         return True
     return None
+
+
+def _metadata_for_metric(metric: str, registry: Optional[MetricRegistry]):
+    if registry is None:
+        return None
+    for candidate in _metric_name_candidates(metric):
+        metadata = registry.get_metadata(candidate)
+        if metadata is not None:
+            return metadata
+    return None
+
+
+def _metric_name_candidates(metric: str) -> List[str]:
+    candidates = [metric, _strip_prefix(metric)]
+    parts = metric.split("_")
+    for index in range(1, len(parts)):
+        candidates.append("_".join(parts[index:]))
+    unique = []
+    for candidate in candidates:
+        if candidate and candidate not in unique:
+            unique.append(candidate)
+    return unique
 
 
 def _collect_input_paths(input_path: str) -> List[Path]:

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -55,23 +55,10 @@ def audio_loader_setup(audio, io):
 
 
 def _create_populated_registry() -> MetricRegistry:
-    """Create a registry populated with all importable package metrics."""
-    import versa as versa_package
+    """Create a registry populated with metric metadata."""
+    from versa.metric_discovery import create_metric_discovery_registry
 
-    registry = MetricRegistry()
-    for name in dir(versa_package):
-        if not name.startswith("register_") or not name.endswith("_metric"):
-            continue
-        register_fn = getattr(versa_package, name)
-        if not callable(register_fn):
-            continue
-        try:
-            register_fn(registry)
-        except Exception as e:
-            logging.getLogger(__name__).warning(
-                "Failed to register metric via %s: %s", name, e
-            )
-    return registry
+    return create_metric_discovery_registry(include_runtime_imports=False)
 
 
 def load_score_modules(
@@ -315,6 +302,12 @@ class VersaScorer:
                         f"Cannot use {metric_name} because no ground truth text is provided"
                     )
                     continue
+
+                from versa.metric_registry import register_metric_for_config
+
+                register_metric_for_config(
+                    self.registry, metric_name, logger=self.logger
+                )
 
                 # Create metric instance
                 metric_config = {**config, "use_gpu": use_gpu}


### PR DESCRIPTION
## Summary

- Make optional metric modules lazy-loaded so reporting, visualization, and metric discovery can run without importing model-backed dependencies.
- Add metadata-backed reporting categories/directions and wire `versa-visualize` to source-discovered metric metadata.
- Add `versa-score --report` report generation for utterance-level scoring outputs.
- Add offline-focused tests for lightweight imports, registry alias metadata, and scorer report export.

## Validation

- `/opt/homebrew/Caskroom/miniforge/base/envs/versa-dev/bin/python -m pytest test/test_reporting.py test/test_metrics/test_definition.py -q`
- `/opt/homebrew/Caskroom/miniforge/base/envs/versa-dev/bin/python versa/bin/visualize.py demo/reporting_example_results.jsonl --out /tmp/versa-report-smoke.html`
- `/opt/homebrew/Caskroom/miniforge/base/envs/versa-dev/bin/scorer.py --score_config egs/separate_metrics/pesq.yaml --gt test/test_samples/test1.scp --pred test/test_samples/test2.scp --output_file /tmp/versa-score-report-results.jsonl --io soundfile --report /tmp/versa-score-report.html`
- `/opt/homebrew/Caskroom/miniforge/base/envs/versa-dev/bin/python versa/bin/scorer.py --list-metrics >/tmp/versa-list-metrics.txt`

Upstream target intended for final review: `wavlab-speech/versa:main`.