### PR TITLE
Speaker similarity fix 

### DIFF
--- a/test/test_metrics/test_base_metrics.py
+++ b/test/test_metrics/test_base_metrics.py
@@ -45,8 +45,16 @@ from versa.utterance_metrics.sheet_ssqa import (
     SheetSsqaMetric,
     register_sheet_ssqa_metric,
 )
-from versa.utterance_metrics.singer import SingerMetric, register_singer_metric
-from versa.utterance_metrics.speaker import SpeakerMetric, register_speaker_metric
+from versa.utterance_metrics.singer import (
+    SingerMetric,
+    register_singer_metric,
+    singer_metric,
+)
+from versa.utterance_metrics.speaker import (
+    SpeakerMetric,
+    register_speaker_metric,
+    speaker_metric,
+)
 from versa.utterance_metrics.squim import (
     SquimNoRefMetric,
     SquimRefMetric,
@@ -558,6 +566,35 @@ def test_speaker_metric_class_returns_existing_key(monkeypatch):
     assert calls["fs"] == 22050
 
 
+def test_speaker_metric_warns_for_low_sample_rate(caplog):
+    class DummyEmbedding:
+        def __init__(self, values):
+            self.values = np.asarray([values], dtype=np.float32)
+
+        def squeeze(self, axis):
+            self.values = np.squeeze(self.values, axis=axis)
+            return self
+
+        def cpu(self):
+            return self
+
+        def numpy(self):
+            return self.values
+
+    class DummySpeakerModel:
+        def __call__(self, audio):
+            return DummyEmbedding([1.0, 0.0])
+
+    pred, ref = _audio_pair(length=8000)
+    caplog.set_level("WARNING", logger="versa.utterance_metrics.speaker")
+
+    scores = speaker_metric(DummySpeakerModel(), pred, ref, 8000)
+
+    assert scores == {"spk_similarity": pytest.approx(1.0)}
+    assert "below 16 kHz may be unreliable" in caplog.text
+    assert "default RawNet3" in caplog.text
+
+
 def test_register_speaker_metric():
     registry = MetricRegistry()
 
@@ -606,6 +643,24 @@ def test_singer_metric_class_returns_existing_key(monkeypatch):
     assert calls["setup"]["model_name"] == "contrastive"
     assert calls["fs"] == 22050
     assert calls["target_sr"] == 48000
+
+
+def test_singer_metric_warns_for_low_sample_rate(caplog):
+    class DummySingerModel:
+        def parameters(self):
+            yield torch.nn.Parameter(torch.empty(0))
+
+        def __call__(self, audio):
+            return torch.tensor([[1.0, 0.0]], dtype=torch.float32)
+
+    pred, ref = _audio_pair(length=8000)
+    caplog.set_level("WARNING", logger="versa.utterance_metrics.singer")
+
+    scores = singer_metric(DummySingerModel(), pred, ref, 8000)
+
+    assert scores == {"singer_similarity": pytest.approx(1.0)}
+    assert "below the 44100 Hz target may be unreliable" in caplog.text
+    assert "singer identity embedding models" in caplog.text
 
 
 def test_register_singer_metric():

--- a/test/test_metrics/test_emo_similarity.py
+++ b/test/test_metrics/test_emo_similarity.py
@@ -7,6 +7,28 @@ import pytest
 from versa.utterance_metrics.emo_similarity import Emo2vecMetric, is_emo2vec_available
 
 
+def test_emotion_metric_warns_for_low_sample_rate(caplog):
+    class DummyModel:
+        def extract_feature(self, audio, fs=16000):
+            return np.asarray([1.0, 0.0], dtype=np.float32)
+
+    metric = object.__new__(Emo2vecMetric)
+    metric.model = DummyModel()
+    audio_8k_1 = np.random.random(8000)
+    audio_8k_2 = np.random.random(8000)
+    caplog.set_level("WARNING", logger="versa.utterance_metrics.emo_similarity")
+
+    result = metric.compute(
+        audio_8k_1,
+        audio_8k_2,
+        metadata={"sample_rate": 8000},
+    )
+
+    assert result == {"emotion_similarity": pytest.approx(1.0)}
+    assert "below 16 kHz may be unreliable" in caplog.text
+    assert "EMO2VEC embedding models" in caplog.text
+
+
 # -------------------------------
 # Helper: Generate a fixed WAV file
 # -------------------------------
@@ -132,7 +154,7 @@ def test_utterance_emotion(use_gpu, fixed_audio, fixed_audio_2):
     emotion_sim = result["emotion_similarity"]
     assert isinstance(emotion_sim, float), "emotion_similarity should be a float"
 
-    # Check that the similarity score is reasonable (between -1 and 1 for cosine similarity)
+    # Check that the similarity score is reasonable for cosine similarity.
     assert (
         -1.0 <= emotion_sim <= 1.0
     ), f"Emotion similarity should be between -1 and 1, got {emotion_sim}"

--- a/versa/utterance_metrics/emo_similarity.py
+++ b/versa/utterance_metrics/emo_similarity.py
@@ -8,9 +8,12 @@
 import logging
 import os
 from pathlib import Path
-from typing import Dict, Any, Optional, Union
+from typing import Dict, Any, Union
 
 import numpy as np
+
+from versa.audio_utils import resample_audio
+from versa.definition import BaseMetric, MetricMetadata, MetricCategory, MetricType
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +30,6 @@ except ImportError:
     )
     EMO2VEC = None
     EMO2VEC_AVAILABLE = False
-
-from versa.audio_utils import resample_audio
-from versa.definition import BaseMetric, MetricMetadata, MetricCategory, MetricType
 
 
 class Emo2vecNotAvailableError(RuntimeError):
@@ -115,6 +115,12 @@ class Emo2vecMetric(BaseMetric):
         gt_x = np.asarray(gt_x)
 
         # NOTE(jiatong): only work for 16000 Hz
+        if fs < 16000:
+            logger.warning(
+                "Emotion similarity with sampling rates below 16 kHz may be "
+                "unreliable for EMO2VEC embedding models."
+            )
+
         if fs != 16000:
             gt_x = resample_audio(gt_x, fs, 16000)
             pred_x = resample_audio(pred_x, fs, 16000)

--- a/versa/utterance_metrics/singer.py
+++ b/versa/utterance_metrics/singer.py
@@ -3,11 +3,15 @@
 # Adapted from speaker similarity code for singer identity
 # Uses SSL singer identity models from SonyCSLParis/ssl-singer-identity
 
+import logging
+
 import numpy as np
 import torch
 
 from versa.audio_utils import resample_audio
 from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
+
+logger = logging.getLogger(__name__)
 
 
 def singer_model_setup(
@@ -80,6 +84,13 @@ def singer_metric(model, pred_x, gt_x, fs, target_sr=44100):
     Returns:
         dict: Dictionary containing singer similarity score
     """
+    if fs < target_sr:
+        logger.warning(
+            "Singer similarity with sampling rates below the %s Hz target may be "
+            "unreliable for singer identity embedding models.",
+            target_sr,
+        )
+
     # Resample to target sample rate if needed (singer models expect 44.1kHz)
     if fs != target_sr:
         gt_x = resample_audio(gt_x, fs, target_sr)
@@ -123,6 +134,13 @@ def singer_metric_batch(model, audio_batch, fs, target_sr=44100):
     Returns:
         np.ndarray: Singer embeddings (batch_size, 1000)
     """
+    if fs < target_sr:
+        logger.warning(
+            "Singer embeddings with sampling rates below the %s Hz target may be "
+            "unreliable for singer identity embedding models.",
+            target_sr,
+        )
+
     # Resample if needed
     if fs != target_sr:
         resampled_batch = []

--- a/versa/utterance_metrics/speaker.py
+++ b/versa/utterance_metrics/speaker.py
@@ -3,6 +3,8 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+import logging
+
 import numpy as np
 
 from versa.audio_utils import resample_audio
@@ -13,6 +15,8 @@ except ImportError:
     Speech2Embedding = None
 
 from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
+
+logger = logging.getLogger(__name__)
 
 
 def speaker_model_setup(
@@ -54,6 +58,12 @@ def speaker_model_setup(
 
 def speaker_metric(model, pred_x, gt_x, fs):
     # NOTE(jiatong): only work for 16000 Hz
+    if fs < 16000:
+        logger.warning(
+            "Speaker similarity with sampling rates below 16 kHz may be unreliable "
+            "for speaker embedding models such as the default RawNet3 model."
+        )
+
     if fs != 16000:
         gt_x = resample_audio(gt_x, fs, 16000)
         pred_x = resample_audio(pred_x, fs, 16000)


### PR DESCRIPTION
## Summary

- Add warnings when speaker similarity, singer identity similarity, and EMO2VEC emotion similarity receive audio below their embedding model target sample rates.
- Keep existing resampling behavior intact while making potentially unreliable upsampled embedding scores visible to users.
- Add lightweight tests that assert the warning behavior without requiring model downloads.

## Motivation

Issue wavlab-speech/versa#83 notes that speaker embedding similarity can be misleading for audio sampled below 16 kHz, especially with the default RawNet3-style path. The same concern applies to similar learned embedding comparisons that silently upsample lower-rate audio before scoring.