### PR TITLE
Add support for parallel scoring with --num_workers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,13 +176,18 @@ python versa/bin/scorer.py \
 
 `--resume` reads existing JSONL rows from `--output_file`, skips utterance keys
 that have already been scored, and preserves their results. This is useful for
-long-running evaluations that are interrupted or restarted.
+long-running evaluations that are interrupted or restarted. With
+`--num_workers > 1`, newly computed rows are appended in input key order, while
+existing rows keep their original positions in the file; the returned scores are
+ordered by input key, but a resumed JSONL file may not be globally sorted by
+input key.
 
 `--num_workers` runs utterance-level CPU scoring in local worker processes while
-preserving input key order in the JSONL output. GPU scoring, metric-oriented
-scoring (`--scoring_mode metric`), and corpus/distributional metrics remain
-serial in this first implementation; `--num_workers > 1` cannot be combined
-with `--use_gpu`.
+preserving input key order in newly written JSONL output for non-resume runs.
+GPU scoring, metric-oriented scoring (`--scoring_mode metric`), and
+corpus/distributional metrics remain serial in this first implementation;
+`--num_workers > 1` cannot be combined with `--use_gpu`, `--scoring_mode
+metric`, or corpus-only configurations.
 
 `--scoring_mode metric` loads and runs one metric at a time, then releases
 metric resources before moving to the next metric. This can reduce peak GPU

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ python versa/bin/scorer.py \
     --gt test/test_samples/test1.scp \
     --pred test/test_samples/test2.scp \
     --output_file test_result \
-    --io soundfile
+    --io soundfile \
+    --num_workers 4
 
 # With Kaldi-ARK style input (compatible with ESPnet)
 python versa/bin/scorer.py \
@@ -174,8 +175,14 @@ python versa/bin/scorer.py \
 ```
 
 `--resume` reads existing JSONL rows from `--output_file`, skips utterance keys
-that have already been scored, and appends only new results. This is useful for
+that have already been scored, and preserves their results. This is useful for
 long-running evaluations that are interrupted or restarted.
+
+`--num_workers` runs utterance-level CPU scoring in local worker processes while
+preserving input key order in the JSONL output. GPU scoring, metric-oriented
+scoring (`--scoring_mode metric`), and corpus/distributional metrics remain
+serial in this first implementation; `--num_workers > 1` cannot be combined
+with `--use_gpu`.
 
 `--scoring_mode metric` loads and runs one metric at a time, then releases
 metric resources before moving to the next metric. This can reduce peak GPU

--- a/test/test_pipeline/test_local_workers.py
+++ b/test/test_pipeline/test_local_workers.py
@@ -83,7 +83,8 @@ def test_parallel_resume_skips_existing_key_and_writes_input_order(tmp_path):
     completed_key = keys[-1]
     output_file = tmp_path / "scores.jsonl"
     output_file.write_text(
-        json.dumps({"key": completed_key, "constant": 3.0}) + "\n", encoding="utf-8",
+        json.dumps({"key": completed_key, "constant": 3.0}) + "\n",
+        encoding="utf-8",
     )
 
     score_info = scorer.score_utterances(

--- a/test/test_pipeline/test_local_workers.py
+++ b/test/test_pipeline/test_local_workers.py
@@ -1,0 +1,118 @@
+import json
+
+import pytest
+
+from versa.bin.scorer import get_parser
+from versa.definition import (
+    BaseMetric,
+    MetricCategory,
+    MetricMetadata,
+    MetricRegistry,
+    MetricType,
+)
+from versa.scorer_shared import VersaScorer, find_files
+
+
+class ConstantMetric(BaseMetric):
+    calls = 0
+
+    def _setup(self):
+        pass
+
+    def compute(self, predictions, references=None, metadata=None):
+        ConstantMetric.calls += 1
+        return 1.0
+
+    def get_metadata(self):
+        return MetricMetadata(
+            name="constant",
+            category=MetricCategory.INDEPENDENT,
+            metric_type=MetricType.FLOAT,
+            requires_reference=False,
+            requires_text=False,
+            gpu_compatible=False,
+            auto_install=False,
+            dependencies=[],
+            description="Dependency-light test metric.",
+        )
+
+
+def _scorer_and_files():
+    registry = MetricRegistry()
+    registry.register(ConstantMetric, ConstantMetric().get_metadata())
+    scorer = VersaScorer(registry)
+    metric_suite = scorer.load_metrics([{"name": "constant"}], use_gt=False)
+    sample_file = next(iter(find_files("test/test_samples/test2").values()))
+    gen_files = {f"utterance-{index}": sample_file for index in range(3)}
+    return scorer, metric_suite, gen_files
+
+
+def _read_jsonl(path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+
+def test_num_workers_cli_defaults_to_serial_and_accepts_parallel():
+    parser = get_parser()
+
+    assert parser.parse_args([]).num_workers == 1
+    assert parser.parse_args(["--num_workers", "2"]).num_workers == 2
+
+
+def test_parallel_matches_serial_and_preserves_input_order(tmp_path):
+    scorer, metric_suite, gen_files = _scorer_and_files()
+    serial_scores = scorer.score_utterances(
+        gen_files, metric_suite, io="soundfile", num_workers=1
+    )
+    output_file = tmp_path / "parallel.jsonl"
+    parallel_scores = scorer.score_utterances(
+        gen_files,
+        metric_suite,
+        output_file=str(output_file),
+        io="soundfile",
+        num_workers=2,
+    )
+
+    assert parallel_scores == serial_scores
+    assert [score["key"] for score in parallel_scores] == list(gen_files)
+    assert _read_jsonl(output_file) == parallel_scores
+
+
+def test_parallel_resume_skips_existing_key_and_writes_input_order(tmp_path):
+    scorer, metric_suite, gen_files = _scorer_and_files()
+    keys = list(gen_files)
+    completed_key = keys[-1]
+    output_file = tmp_path / "scores.jsonl"
+    output_file.write_text(
+        json.dumps({"key": completed_key, "constant": 3.0}) + "\n",
+        encoding="utf-8",
+    )
+
+    score_info = scorer.score_utterances(
+        gen_files,
+        metric_suite,
+        output_file=str(output_file),
+        io="soundfile",
+        resume=True,
+        num_workers=2,
+    )
+
+    assert [score["key"] for score in score_info] == keys
+    assert score_info[-1] == {"key": completed_key, "constant": 3.0}
+    assert _read_jsonl(output_file) == score_info
+
+
+def test_one_worker_uses_existing_serial_path(monkeypatch):
+    scorer, metric_suite, gen_files = _scorer_and_files()
+    monkeypatch.setattr(
+        scorer,
+        "_score_utterances_parallel",
+        lambda *args, **kwargs: pytest.fail("parallel path was used"),
+    )
+
+    ConstantMetric.calls = 0
+    score_info = scorer.score_utterances(
+        gen_files, metric_suite, io="soundfile", num_workers=1
+    )
+
+    assert len(score_info) == len(gen_files)
+    assert ConstantMetric.calls == len(gen_files)

--- a/test/test_pipeline/test_local_workers.py
+++ b/test/test_pipeline/test_local_workers.py
@@ -83,8 +83,7 @@ def test_parallel_resume_skips_existing_key_and_writes_input_order(tmp_path):
     completed_key = keys[-1]
     output_file = tmp_path / "scores.jsonl"
     output_file.write_text(
-        json.dumps({"key": completed_key, "constant": 3.0}) + "\n",
-        encoding="utf-8",
+        json.dumps({"key": completed_key, "constant": 3.0}) + "\n", encoding="utf-8",
     )
 
     score_info = scorer.score_utterances(

--- a/test/test_pipeline/test_local_workers.py
+++ b/test/test_pipeline/test_local_workers.py
@@ -98,7 +98,11 @@ def test_parallel_resume_skips_existing_key_and_writes_input_order(tmp_path):
 
     assert [score["key"] for score in score_info] == keys
     assert score_info[-1] == {"key": completed_key, "constant": 3.0}
-    assert _read_jsonl(output_file) == score_info
+    assert _read_jsonl(output_file) == [
+        {"key": completed_key, "constant": 3.0},
+        {"key": keys[0], "constant": 1.0},
+        {"key": keys[1], "constant": 1.0},
+    ]
 
 
 def test_one_worker_uses_existing_serial_path(monkeypatch):

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -23,18 +23,13 @@ def get_parser() -> argparse.Namespace:
     """Get argument parser."""
     parser = argparse.ArgumentParser(description="Speech Evaluation Interface")
     parser.add_argument(
-        "--pred",
-        type=str,
-        help="Wav.scp for generated waveforms.",
+        "--pred", type=str, help="Wav.scp for generated waveforms.",
     )
     parser.add_argument(
         "--score_config", type=str, default=None, help="Configuration of Score Config"
     )
     parser.add_argument(
-        "--gt",
-        type=str,
-        default=None,
-        help="Wav.scp for ground truth waveforms.",
+        "--gt", type=str, default=None, help="Wav.scp for ground truth waveforms.",
     )
     parser.add_argument(
         "--text", type=str, default=None, help="Path of ground truth transcription."
@@ -127,9 +122,7 @@ def get_parser() -> argparse.Namespace:
         help="Maximum outlier examples to keep per metric in --report.",
     )
     parser.add_argument(
-        "--list-metrics",
-        action="store_true",
-        help="List registered metrics and exit.",
+        "--list-metrics", action="store_true", help="List registered metrics and exit.",
     )
     parser.add_argument(
         "--describe-metric",
@@ -193,9 +186,7 @@ def main():
     if args.num_workers < 1:
         parser.error("--num_workers must be at least 1")
     if args.num_workers > 1 and args.use_gpu:
-        parser.error(
-            "--num_workers > 1 is CPU-only and cannot be used with --use_gpu"
-        )
+        parser.error("--num_workers > 1 is CPU-only and cannot be used with --use_gpu")
 
     if args.list_metrics or args.describe_metric or args.recommend_config:
         try:
@@ -420,13 +411,7 @@ def main():
 
 
 def _write_report(
-    score_info,
-    report_path,
-    *,
-    report_format,
-    group_by,
-    outlier_limit,
-    registry,
+    score_info, report_path, *, report_format, group_by, outlier_limit, registry,
 ):
     from pathlib import Path
 
@@ -449,10 +434,7 @@ def _write_report(
         }.get(output_path.suffix.lower(), "html")
 
     analysis = analyze_records(
-        score_info,
-        group_by=group_by,
-        outlier_limit=outlier_limit,
-        registry=registry,
+        score_info, group_by=group_by, outlier_limit=outlier_limit, registry=registry,
     )
     if report_format == "html":
         write_html_report(analysis, report_path)

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -52,6 +52,12 @@ def get_parser() -> argparse.Namespace:
         "--use_gpu", action="store_true", help="whether to use GPU if it can"
     )
     parser.add_argument(
+        "--num_workers",
+        type=int,
+        default=1,
+        help="Number of local CPU worker processes for utterance scoring.",
+    )
+    parser.add_argument(
         "--io",
         type=str,
         default="kaldi",
@@ -183,6 +189,13 @@ def get_parser() -> argparse.Namespace:
 def main():
     parser = get_parser()
     args = parser.parse_args()
+
+    if args.num_workers < 1:
+        parser.error("--num_workers must be at least 1")
+    if args.num_workers > 1 and args.use_gpu:
+        parser.error(
+            "--num_workers > 1 is CPU-only and cannot be used with --use_gpu"
+        )
 
     if args.list_metrics or args.describe_metric or args.recommend_config:
         try:
@@ -354,6 +367,7 @@ def main():
             output_file=args.output_file,
             io=args.io,
             resume=args.resume,
+            num_workers=args.num_workers,
         )
         logging.info("Summary: {}".format(compute_summary(score_info)))
     elif utterance_metric_count == 0:

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -324,6 +324,13 @@ def main():
         )
     ]
 
+    if args.num_workers > 1 and args.scoring_mode == "metric":
+        parser.error(
+            "--num_workers > 1 is only supported with --scoring_mode utterance"
+        )
+    if args.num_workers > 1 and len(utterance_score_config) == 0:
+        parser.error("--num_workers > 1 requires at least one utterance-level metric")
+
     score_info = []
     if args.scoring_mode == "metric":
         score_info = scorer.score_utterances_by_metric(

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -23,13 +23,18 @@ def get_parser() -> argparse.Namespace:
     """Get argument parser."""
     parser = argparse.ArgumentParser(description="Speech Evaluation Interface")
     parser.add_argument(
-        "--pred", type=str, help="Wav.scp for generated waveforms.",
+        "--pred",
+        type=str,
+        help="Wav.scp for generated waveforms.",
     )
     parser.add_argument(
         "--score_config", type=str, default=None, help="Configuration of Score Config"
     )
     parser.add_argument(
-        "--gt", type=str, default=None, help="Wav.scp for ground truth waveforms.",
+        "--gt",
+        type=str,
+        default=None,
+        help="Wav.scp for ground truth waveforms.",
     )
     parser.add_argument(
         "--text", type=str, default=None, help="Path of ground truth transcription."
@@ -122,7 +127,9 @@ def get_parser() -> argparse.Namespace:
         help="Maximum outlier examples to keep per metric in --report.",
     )
     parser.add_argument(
-        "--list-metrics", action="store_true", help="List registered metrics and exit.",
+        "--list-metrics",
+        action="store_true",
+        help="List registered metrics and exit.",
     )
     parser.add_argument(
         "--describe-metric",
@@ -411,7 +418,13 @@ def main():
 
 
 def _write_report(
-    score_info, report_path, *, report_format, group_by, outlier_limit, registry,
+    score_info,
+    report_path,
+    *,
+    report_format,
+    group_by,
+    outlier_limit,
+    registry,
 ):
     from pathlib import Path
 
@@ -434,7 +447,10 @@ def _write_report(
         }.get(output_path.suffix.lower(), "html")
 
     analysis = analyze_records(
-        score_info, group_by=group_by, outlier_limit=outlier_limit, registry=registry,
+        score_info,
+        group_by=group_by,
+        outlier_limit=outlier_limit,
+        registry=registry,
     )
     if report_format == "html":
         write_html_report(analysis, report_path)

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -116,7 +116,10 @@ def load_score_modules(
         )
     ]
     return scorer.load_metrics(
-        score_config, use_gt=use_gt, use_gt_text=use_gt_text, use_gpu=use_gpu,
+        score_config,
+        use_gt=use_gt,
+        use_gt_text=use_gt_text,
+        use_gpu=use_gpu,
     )
 
 
@@ -202,7 +205,8 @@ def _ensure_append_starts_on_new_line(output_file: str) -> None:
 
 
 def _write_jsonl_scores(
-    output_file: Optional[str], score_info: List[Dict[str, Any]],
+    output_file: Optional[str],
+    score_info: List[Dict[str, Any]],
 ) -> None:
     """Write utterance scores as JSONL in the current utterance order."""
     if not output_file:
@@ -435,7 +439,11 @@ class VersaScorer:
                 gen_wav = wav_normalize(gen_wav)
 
                 if not self._validate_audio(
-                    gen_wav, gen_sr, key, "generated", metric_suite.metrics.keys(),
+                    gen_wav,
+                    gen_sr,
+                    key,
+                    "generated",
+                    metric_suite.metrics.keys(),
                 ):
                     continue
 
@@ -452,7 +460,11 @@ class VersaScorer:
                     gt_wav = wav_normalize(gt_wav)
 
                     if not self._validate_audio(
-                        gt_wav, gt_sr, key, "ground truth", metric_suite.metrics.keys(),
+                        gt_wav,
+                        gt_sr,
+                        key,
+                        "ground truth",
+                        metric_suite.metrics.keys(),
                     ):
                         continue
 
@@ -584,7 +596,10 @@ class VersaScorer:
                 continue
 
             metric_suite = self.load_metrics(
-                [config], use_gt=use_gt, use_gt_text=use_gt_text, use_gpu=use_gpu,
+                [config],
+                use_gt=use_gt,
+                use_gt_text=use_gt_text,
+                use_gpu=use_gpu,
             )
             metric_suite = MetricSuite(
                 {

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -227,6 +227,13 @@ def _write_jsonl_scores(
             f.write(f"{printable_result}\n")
 
 
+def _write_jsonl_score(file_handle, utt_score: Dict[str, Any]) -> None:
+    """Write one utterance score and flush it for resume checkpointing."""
+    printable_result = json.dumps(utt_score, default=default_numpy_serializer)
+    file_handle.write(f"{printable_result}\n")
+    file_handle.flush()
+
+
 def _release_metric_resources() -> None:
     """Best-effort cleanup after unloading model-backed metrics."""
     gc.collect()
@@ -420,6 +427,7 @@ class VersaScorer:
                 io=io,
                 existing_scores=existing_scores,
                 completed_keys=completed_keys,
+                resume=resume,
                 num_workers=num_workers,
             )
 
@@ -508,6 +516,7 @@ class VersaScorer:
         io: str,
         existing_scores: Dict[str, Dict[str, Any]],
         completed_keys: set,
+        resume: bool,
         num_workers: int,
     ) -> List[Dict[str, Any]]:
         """Score utterances in process-local metric suites."""
@@ -536,22 +545,34 @@ class VersaScorer:
             for name, metric in metric_suite.metrics.items()
         ]
         new_scores = {}
-        with ProcessPoolExecutor(
-            max_workers=num_workers,
-            initializer=_initialize_score_worker,
-            initargs=(metric_specs,),
-        ) as executor:
-            results = executor.map(_score_utterance_worker, jobs)
-            for result in tqdm(results, total=len(jobs)):
-                if result is not None:
-                    new_scores[result["key"]] = result
+        file_handle = None
+        if output_file:
+            mode = "a" if resume else "w"
+            if resume:
+                _ensure_append_starts_on_new_line(output_file)
+            file_handle = open(output_file, mode, encoding="utf-8")
+
+        try:
+            with ProcessPoolExecutor(
+                max_workers=num_workers,
+                initializer=_initialize_score_worker,
+                initargs=(metric_specs,),
+            ) as executor:
+                results = executor.map(_score_utterance_worker, jobs)
+                for result in tqdm(results, total=len(jobs)):
+                    if result is not None:
+                        new_scores[result["key"]] = result
+                        if file_handle:
+                            _write_jsonl_score(file_handle, result)
+        finally:
+            if file_handle:
+                file_handle.close()
 
         score_info = [
             existing_scores.get(key, new_scores.get(key))
             for key in gen_files
             if key in existing_scores or key in new_scores
         ]
-        _write_jsonl_scores(output_file, score_info)
         self.logger.info("Scoring completed. Results saved to %s", output_file)
         return score_info
 

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -43,10 +43,7 @@ def _initialize_score_worker(metric_specs):
     """Create process-local metric instances for utterance scoring."""
     global _worker_metric_suite
     _worker_metric_suite = MetricSuite(
-        {
-            name: metric_class(config)
-            for name, metric_class, config in metric_specs
-        }
+        {name: metric_class(config) for name, metric_class, config in metric_specs}
     )
 
 
@@ -58,23 +55,17 @@ def _score_utterance_worker(utterance):
     gen_sr, gen_wav = load_audio(gen_file, io)
     gen_wav = wav_normalize(gen_wav)
     metric_names = _worker_metric_suite.metrics.keys()
-    if not scorer._validate_audio(
-        gen_wav, gen_sr, key, "generated", metric_names
-    ):
+    if not scorer._validate_audio(gen_wav, gen_sr, key, "generated", metric_names):
         return None
 
     gt_wav, gt_sr = None, None
     if gt_file is not None:
         gt_sr, gt_wav = load_audio(gt_file, io)
         gt_wav = wav_normalize(gt_wav)
-        if not scorer._validate_audio(
-            gt_wav, gt_sr, key, "ground truth", metric_names
-        ):
+        if not scorer._validate_audio(gt_wav, gt_sr, key, "ground truth", metric_names):
             return None
 
-    gen_wav, gt_wav, gen_sr = scorer._align_sample_rates(
-        gen_wav, gt_wav, gen_sr, gt_sr
-    )
+    gen_wav, gt_wav, gen_sr = scorer._align_sample_rates(gen_wav, gt_wav, gen_sr, gt_sr)
     return ScoreProcessor(_worker_metric_suite).process_batch(
         [(key, gen_wav, gt_wav, gen_sr, text)]
     )[0]
@@ -125,10 +116,7 @@ def load_score_modules(
         )
     ]
     return scorer.load_metrics(
-        score_config,
-        use_gt=use_gt,
-        use_gt_text=use_gt_text,
-        use_gpu=use_gpu,
+        score_config, use_gt=use_gt, use_gt_text=use_gt_text, use_gpu=use_gpu,
     )
 
 
@@ -214,8 +202,7 @@ def _ensure_append_starts_on_new_line(output_file: str) -> None:
 
 
 def _write_jsonl_scores(
-    output_file: Optional[str],
-    score_info: List[Dict[str, Any]],
+    output_file: Optional[str], score_info: List[Dict[str, Any]],
 ) -> None:
     """Write utterance scores as JSONL in the current utterance order."""
     if not output_file:
@@ -448,11 +435,7 @@ class VersaScorer:
                 gen_wav = wav_normalize(gen_wav)
 
                 if not self._validate_audio(
-                    gen_wav,
-                    gen_sr,
-                    key,
-                    "generated",
-                    metric_suite.metrics.keys(),
+                    gen_wav, gen_sr, key, "generated", metric_suite.metrics.keys(),
                 ):
                     continue
 
@@ -469,11 +452,7 @@ class VersaScorer:
                     gt_wav = wav_normalize(gt_wav)
 
                     if not self._validate_audio(
-                        gt_wav,
-                        gt_sr,
-                        key,
-                        "ground truth",
-                        metric_suite.metrics.keys(),
+                        gt_wav, gt_sr, key, "ground truth", metric_suite.metrics.keys(),
                     ):
                         continue
 
@@ -605,10 +584,7 @@ class VersaScorer:
                 continue
 
             metric_suite = self.load_metrics(
-                [config],
-                use_gt=use_gt,
-                use_gt_text=use_gt_text,
-                use_gpu=use_gpu,
+                [config], use_gt=use_gt, use_gt_text=use_gt_text, use_gpu=use_gpu,
             )
             metric_suite = MetricSuite(
                 {

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -7,6 +7,8 @@ import gc
 import json
 import logging
 import os
+from concurrent.futures import ProcessPoolExecutor
+
 import kaldiio
 import soundfile as sf
 import yaml
@@ -33,6 +35,49 @@ from versa.utils_shared import (
     load_audio,
     wav_normalize,
 )
+
+_worker_metric_suite = None
+
+
+def _initialize_score_worker(metric_specs):
+    """Create process-local metric instances for utterance scoring."""
+    global _worker_metric_suite
+    _worker_metric_suite = MetricSuite(
+        {
+            name: metric_class(config)
+            for name, metric_class, config in metric_specs
+        }
+    )
+
+
+def _score_utterance_worker(utterance):
+    """Load and score one utterance without writing output files."""
+    key, gen_file, gt_file, text, io = utterance
+    scorer = VersaScorer(MetricRegistry())
+
+    gen_sr, gen_wav = load_audio(gen_file, io)
+    gen_wav = wav_normalize(gen_wav)
+    metric_names = _worker_metric_suite.metrics.keys()
+    if not scorer._validate_audio(
+        gen_wav, gen_sr, key, "generated", metric_names
+    ):
+        return None
+
+    gt_wav, gt_sr = None, None
+    if gt_file is not None:
+        gt_sr, gt_wav = load_audio(gt_file, io)
+        gt_wav = wav_normalize(gt_wav)
+        if not scorer._validate_audio(
+            gt_wav, gt_sr, key, "ground truth", metric_names
+        ):
+            return None
+
+    gen_wav, gt_wav, gen_sr = scorer._align_sample_rates(
+        gen_wav, gt_wav, gen_sr, gt_sr
+    )
+    return ScoreProcessor(_worker_metric_suite).process_batch(
+        [(key, gen_wav, gt_wav, gen_sr, text)]
+    )[0]
 
 
 def audio_loader_setup(audio, io):
@@ -332,9 +377,12 @@ class VersaScorer:
         io: str = "kaldi",
         batch_size: int = 1,
         resume: bool = False,
+        num_workers: int = 1,
     ) -> List[Dict[str, Any]]:
         """Score individual utterances."""
 
+        if num_workers < 1:
+            raise ValueError("num_workers must be at least 1")
         metric_suite = MetricSuite(
             {
                 name: metric
@@ -342,6 +390,13 @@ class VersaScorer:
                 if metric.get_metadata().category != MetricCategory.DISTRIBUTIONAL
             }
         )
+        if num_workers > 1 and any(
+            getattr(metric, "config", {}).get("use_gpu", False)
+            for metric in metric_suite.metrics.values()
+        ):
+            raise ValueError(
+                "Local multiprocessing is CPU-only; use num_workers=1 with GPU metrics"
+            )
         existing_scores = _load_existing_jsonl_scores(output_file) if resume else {}
         completed_keys = set(existing_scores).intersection(gen_files)
         if resume and output_file:
@@ -353,6 +408,19 @@ class VersaScorer:
         elif resume:
             self.logger.warning(
                 "Resume requested without output_file; scoring normally"
+            )
+
+        if num_workers > 1:
+            return self._score_utterances_parallel(
+                gen_files,
+                metric_suite,
+                gt_files=gt_files,
+                text_info=text_info,
+                output_file=output_file,
+                io=io,
+                existing_scores=existing_scores,
+                completed_keys=completed_keys,
+                num_workers=num_workers,
             )
 
         processor = ScoreProcessor(metric_suite, output_file, resume=resume)
@@ -428,6 +496,63 @@ class VersaScorer:
             processor.close()
 
         self.logger.info(f"Scoring completed. Results saved to {output_file}")
+        return score_info
+
+    def _score_utterances_parallel(
+        self,
+        gen_files: Dict[str, str],
+        metric_suite: MetricSuite,
+        gt_files: Optional[Dict[str, str]],
+        text_info: Optional[Dict[str, str]],
+        output_file: Optional[str],
+        io: str,
+        existing_scores: Dict[str, Dict[str, Any]],
+        completed_keys: set,
+        num_workers: int,
+    ) -> List[Dict[str, Any]]:
+        """Score utterances in process-local metric suites."""
+        jobs = []
+        for key in gen_files:
+            if key in completed_keys:
+                continue
+            if gt_files is not None and key not in gt_files:
+                self.logger.warning("Ground truth not found for key %s, skipping", key)
+                continue
+            if text_info is not None and key not in text_info:
+                self.logger.warning("Text not found for key %s, skipping", key)
+                continue
+            jobs.append(
+                (
+                    key,
+                    gen_files[key],
+                    gt_files[key] if gt_files is not None else None,
+                    text_info.get(key) if text_info is not None else None,
+                    io,
+                )
+            )
+
+        metric_specs = [
+            (name, metric.__class__, metric.config)
+            for name, metric in metric_suite.metrics.items()
+        ]
+        new_scores = {}
+        with ProcessPoolExecutor(
+            max_workers=num_workers,
+            initializer=_initialize_score_worker,
+            initargs=(metric_specs,),
+        ) as executor:
+            results = executor.map(_score_utterance_worker, jobs)
+            for result in tqdm(results, total=len(jobs)):
+                if result is not None:
+                    new_scores[result["key"]] = result
+
+        score_info = [
+            existing_scores.get(key, new_scores.get(key))
+            for key in gen_files
+            if key in existing_scores or key in new_scores
+        ]
+        _write_jsonl_scores(output_file, score_info)
+        self.logger.info("Scoring completed. Results saved to %s", output_file)
         return score_info
 
     def score_utterances_by_metric(


### PR DESCRIPTION
- Introduced --num_workers argument in scorer.py for CPU-based parallel processing.
- Implemented parallel scoring logic in scorer_shared.py to enhance performance.
- Added tests to validate functionality of parallel scoring and ensure input order preservation.