### PR TITLE
Add SongEval and shared model caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ external toolkits:
 
 ```bash
 pip install ".[audio,text,ml]"
+pip install ".[songeval]" # SongEval Python dependencies only
 pip install ".[external]"  # Git/toolkit-backed metrics
 pip install ".[dev]"       # tests, linting, and formatting
 ```
@@ -90,6 +91,25 @@ still run metrics that do not require that backend. FADTK is only needed for
 FAD/KID-style metrics and can be installed with `tools/install_fadtk.sh` when
 those metrics are selected.
 
+SongEval is an optional, reference-free metric for full songs. Its upstream
+toolkit predicts coherence, musicality, memorability, structural clarity, and
+vocal naturalness on a 1--5 scale. Install its Python dependencies and pinned
+upstream assets explicitly before scoring:
+
+```bash
+PYTHON=python tools/install_songeval.sh
+python versa/bin/scorer.py \
+    --score_config egs/separate_metrics/songeval.yaml \
+    --pred path/to/generated_wav.scp \
+    --output_file songeval.jsonl \
+    --io soundfile \
+    --use_gpu
+```
+
+On first use, VERSA downloads a pinned SongEval checkout into
+`versa_cache/SongEval` and MuQ into `versa_cache/huggingface`. For a fully local
+run, set `model_dir`, `muq_model`, and `offline: true` in the YAML.
+
 If NLTK downloads fail with a certificate verification error, point Python at
 the certificate bundle used by `certifi` before running the tests:
 
@@ -118,6 +138,22 @@ python -m pytest --import-mode=importlib test
 ## 🔧 Usage Examples
 
 ### Basic Usage
+
+Use `--cache_folder` to place downloads for all metrics below one shareable
+root. VERSA shares subdirectories for metrics using the same model backend
+(such as Hugging Face, Whisper, ESPnet, and Torch Hub) and isolates other
+metric-specific files. An explicit `cache_dir` in the score YAML takes
+precedence:
+
+```bash
+python versa/bin/scorer.py \
+    --score_config egs/speech_cpu.yaml \
+    --pred test/test_samples/test2 \
+    --gt test/test_samples/test1 \
+    --output_file test_result \
+    --io dir \
+    --cache_folder /shared/versa_cache
+```
 
 ```bash
 # Direct usage with file paths

--- a/egs/separate_metrics/songeval.yaml
+++ b/egs/separate_metrics/songeval.yaml
@@ -1,5 +1,11 @@
 # SongEval Config
 # More info in https://github.com/ASLP-lab/SongEval
 - name: songeval
-
+  # The installer places the pinned SongEval checkout under this cache.
+  cache_dir: versa_cache
+  # Set to a complete local checkout to override cache_dir/SongEval.
+  # model_dir: /path/to/SongEval
+  # Set to a local MuQ model directory together with offline: true for no-network runs.
+  # muq_model: /path/to/MuQ-large-msd-iter
+  # offline: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,12 @@ jupyter = [
     "jupyter>=1.0.0",
     "matplotlib>=3.3.0",
 ]
+songeval = [
+    "einops",
+    "muq==0.1.0",
+    "omegaconf>=2.3,<3",
+    "safetensors",
+]
 audio = [
     "audioread",
     "ci-sdr",

--- a/test/test_general.py
+++ b/test/test_general.py
@@ -5,11 +5,83 @@ import yaml
 import logging
 
 from versa.scorer_shared import (
+    configure_metric_cache_dirs,
+    configure_shared_cache_environment,
     find_files,
     list_scoring,
     load_score_modules,
     load_summary,
 )
+
+
+def test_configure_metric_cache_dirs_uses_shared_root_and_preserves_overrides(
+    tmp_path,
+):
+    configs = [
+        {"name": "SongEval"},
+        {"name": "qwen2_audio_speaker_age"},
+        {"name": "qwen2_audio_speaker_gender"},
+        {"name": "speaking_rate"},
+        {"name": "whisper_wer", "cache_dir": "/existing/shared-whisper"},
+    ]
+
+    configured = configure_metric_cache_dirs(configs, tmp_path)
+
+    assert configured == [
+        {"name": "SongEval", "cache_dir": str(tmp_path / "songeval")},
+        {
+            "name": "qwen2_audio_speaker_age",
+            "cache_dir": str(tmp_path / "huggingface"),
+        },
+        {
+            "name": "qwen2_audio_speaker_gender",
+            "cache_dir": str(tmp_path / "huggingface"),
+        },
+        {"name": "speaking_rate", "cache_dir": str(tmp_path / "whisper")},
+        {"name": "whisper_wer", "cache_dir": "/existing/shared-whisper"},
+    ]
+    assert configs == [
+        {"name": "SongEval"},
+        {"name": "qwen2_audio_speaker_age"},
+        {"name": "qwen2_audio_speaker_gender"},
+        {"name": "speaking_rate"},
+        {"name": "whisper_wer", "cache_dir": "/existing/shared-whisper"},
+    ]
+
+
+def test_configure_metric_cache_dirs_without_root_returns_original_config():
+    configs = [{"name": "songeval"}]
+
+    assert configure_metric_cache_dirs(configs) is configs
+
+
+def test_configure_shared_cache_environment(monkeypatch, tmp_path):
+    for variable in (
+        "VERSA_CACHE_DIR",
+        "VERSA_HF_CACHE_DIR",
+        "HF_HOME",
+        "HF_HUB_CACHE",
+        "TRANSFORMERS_CACHE",
+        "HF_DATASETS_CACHE",
+        "TORCH_HOME",
+        "NEMO_CACHE_DIR",
+        "XDG_CACHE_HOME",
+    ):
+        monkeypatch.setenv(variable, "previous-cache-value")
+
+    cache_root = configure_shared_cache_environment(tmp_path / "shared-cache")
+
+    hf_cache = cache_root / "huggingface"
+    assert os.environ["VERSA_CACHE_DIR"] == str(cache_root)
+    assert os.environ["VERSA_HF_CACHE_DIR"] == str(hf_cache)
+    assert os.environ["HF_HOME"] == str(hf_cache)
+    assert os.environ["HF_HUB_CACHE"] == str(hf_cache)
+    assert os.environ["TRANSFORMERS_CACHE"] == str(hf_cache)
+    assert os.environ["HF_DATASETS_CACHE"] == str(hf_cache / "datasets")
+    assert os.environ["TORCH_HOME"] == str(cache_root / "torch")
+    assert os.environ["NEMO_CACHE_DIR"] == str(cache_root / "nemo")
+    assert os.environ["XDG_CACHE_HOME"] == str(cache_root)
+
 
 # The expected test values from the original code
 TEST_INFO = {

--- a/test/test_metrics/test_base_metrics.py
+++ b/test/test_metrics/test_base_metrics.py
@@ -417,7 +417,7 @@ def test_new_wer_metric_classes_use_cached_text(
     monkeypatch.setattr(f"{module_name}.{metric_name}", dummy_metric)
 
     pred, _ = _audio_pair()
-    metric = class_name({"model_tag": "tiny-test"})
+    metric = class_name({"model_tag": "tiny-test", "cache_dir": "shared-cache"})
     scores = metric.compute(
         pred,
         metadata={
@@ -429,6 +429,7 @@ def test_new_wer_metric_classes_use_cached_text(
 
     assert scores[hyp_key] == "cached hello"
     assert calls["setup"]["model_tag"] == "tiny-test"
+    assert calls["setup"]["cache_dir"] == "shared-cache"
     assert calls["ref_text"] == "hello"
     assert calls["fs"] == 22050
     assert calls["cache_pred_text"] == "cached hello"
@@ -837,9 +838,13 @@ def test_universa_missing_dependency(monkeypatch):
 def test_qwen2_audio_metric_class_returns_existing_key(monkeypatch):
     calls = {}
 
+    def dummy_setup(**kwargs):
+        calls["setup"] = kwargs
+        return {"model": "dummy"}
+
     monkeypatch.setattr(
         "versa.utterance_metrics.qwen2_audio.qwen2_model_setup",
-        lambda **kwargs: {"model": "dummy"},
+        dummy_setup,
     )
 
     def dummy_base_metric(
@@ -857,13 +862,16 @@ def test_qwen2_audio_metric_class_returns_existing_key(monkeypatch):
 
     pred, _ = _audio_pair()
     metric_class = QWEN2_AUDIO_METRIC_CLASSES["speaker_age"]
-    metric = metric_class({"prompt": "Age?", "max_length": 77})
+    metric = metric_class(
+        {"prompt": "Age?", "max_length": 77, "cache_dir": "shared-hf"}
+    )
     scores = metric.compute(pred, metadata={"sample_rate": 22050})
 
     assert scores == {"qwen_speaker_age": "young adult"}
     assert calls["fs"] == 22050
     assert calls["custom_prompt"] == "Age?"
     assert calls["max_length"] == 77
+    assert calls["setup"]["cache_dir"] == "shared-hf"
 
 
 def test_register_qwen2_audio_metric():
@@ -880,9 +888,13 @@ def test_register_qwen2_audio_metric():
 def test_qwen_omni_metric_class_returns_existing_key(monkeypatch):
     calls = {}
 
+    def dummy_setup(**kwargs):
+        calls["setup"] = kwargs
+        return {"model": "dummy"}
+
     monkeypatch.setattr(
         "versa.utterance_metrics.qwen_omni.qwen_omni_model_setup",
-        lambda **kwargs: {"model": "dummy"},
+        dummy_setup,
     )
 
     def dummy_base_metric(
@@ -900,13 +912,16 @@ def test_qwen_omni_metric_class_returns_existing_key(monkeypatch):
 
     pred, _ = _audio_pair()
     metric_class = QWEN_OMNI_METRIC_CLASSES["speech_emotion"]
-    metric = metric_class({"prompt": "Emotion?", "max_length": 88})
+    metric = metric_class(
+        {"prompt": "Emotion?", "max_length": 88, "cache_dir": "shared-hf"}
+    )
     scores = metric.compute(pred, metadata={"sample_rate": 22050})
 
     assert scores == {"qwen_omni_speech_emotion": "happy"}
     assert calls["fs"] == 22050
     assert calls["custom_prompt"] == "Emotion?"
     assert calls["max_length"] == 88
+    assert calls["setup"]["cache_dir"] == "shared-hf"
 
 
 def test_register_qwen_omni_metric():

--- a/test/test_metrics/test_nomad.py
+++ b/test/test_metrics/test_nomad.py
@@ -158,6 +158,20 @@ class TestNomadMetric:
         assert metric.model is not None
         mock_nomad_class.assert_called_once_with(device="cpu", cache_dir="test_cache")
 
+    @patch("versa.utterance_metrics.nomad.Nomad")
+    def test_cache_dir_takes_precedence_over_legacy_model_cache(self, mock_nomad_class):
+        mock_nomad_class.return_value = Mock()
+
+        NomadMetric(
+            {
+                "use_gpu": False,
+                "cache_dir": "shared-cache",
+                "model_cache": "legacy-cache",
+            }
+        )
+
+        mock_nomad_class.assert_called_once_with(device="cpu", cache_dir="shared-cache")
+
     def test_compute_with_none_predictions(self):
         """Test that compute raises error with None predictions."""
         with patch("versa.utterance_metrics.nomad.Nomad") as mock_nomad_class:

--- a/test/test_metrics/test_pam.py
+++ b/test/test_metrics/test_pam.py
@@ -9,6 +9,23 @@ from packaging.version import parse as V
 from versa.utterance_metrics.pam import PamMetric, PAM, is_pam_available
 
 
+def test_pam_metric_forwards_cache_dir(monkeypatch, tmp_path):
+    calls = {}
+
+    class DummyPam:
+        def __init__(self, **kwargs):
+            calls.update(kwargs)
+
+    monkeypatch.setenv("VERSA_HF_CACHE_DIR", "")
+    monkeypatch.setattr("versa.utterance_metrics.pam.PAM", DummyPam)
+    monkeypatch.setattr("versa.utterance_metrics.pam.PAM_AVAILABLE", True)
+
+    metric = PamMetric({"cache_dir": str(tmp_path), "use_gpu": False})
+
+    assert metric.cache_dir == str(tmp_path)
+    assert calls["cache_dir"] == str(tmp_path)
+
+
 # -------------------------------
 # Helper: Generate a fixed WAV file
 # -------------------------------

--- a/test/test_metrics/test_songeval.py
+++ b/test/test_metrics/test_songeval.py
@@ -1,4 +1,6 @@
 import os
+import sys
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -14,8 +16,12 @@ class DummySongEvalModel:
 
 
 class DummyMuQ:
+    def __init__(self):
+        self.audio_shape = None
+
     def __call__(self, audio, output_hidden_states=True):
         assert output_hidden_states
+        self.audio_shape = tuple(audio.shape)
         hidden_states = [torch.zeros((1, 2, 3), device=audio.device) for _ in range(7)]
         return {"hidden_states": hidden_states}
 
@@ -59,6 +65,221 @@ def test_songeval_metric_validates_predictions(monkeypatch):
         metric.compute(None, metadata={"sample_rate": 16000})
 
 
+@pytest.mark.parametrize(
+    "audio",
+    [
+        np.ones((16000, 2), dtype=np.float32),
+        np.ones((2, 16000), dtype=np.float32),
+    ],
+)
+def test_songeval_metric_downmixes_stereo(audio):
+    muq = DummyMuQ()
+    model_dict = {
+        "device": "cpu",
+        "model": DummySongEvalModel(),
+        "muq": muq,
+    }
+
+    songeval.songeval_metric(model_dict, audio, fs=16000)
+
+    assert muq.audio_shape == (1, 24000)
+
+
+@pytest.mark.parametrize(
+    ("audio", "sample_rate", "message"),
+    [
+        (np.array([], dtype=np.float32), 24000, "non-empty"),
+        (np.array([0.0, np.nan], dtype=np.float32), 24000, "NaN"),
+        (np.ones((2, 3, 4), dtype=np.float32), 24000, "mono audio"),
+        (np.ones(100, dtype=np.float32), 0, "positive integer"),
+        (np.ones(100, dtype=np.float32), 24000.0, "positive integer"),
+    ],
+)
+def test_songeval_metric_rejects_invalid_audio(audio, sample_rate, message):
+    model_dict = {
+        "device": "cpu",
+        "model": DummySongEvalModel(),
+        "muq": DummyMuQ(),
+    }
+
+    with pytest.raises(ValueError, match=message):
+        songeval.songeval_metric(model_dict, audio, fs=sample_rate)
+
+
+def test_songeval_metric_validates_predictor_output_shape():
+    class InvalidModel:
+        def __call__(self, hidden):
+            return torch.ones((1, 4), dtype=torch.float32)
+
+    model_dict = {
+        "device": "cpu",
+        "model": InvalidModel(),
+        "muq": DummyMuQ(),
+    }
+
+    with pytest.raises(RuntimeError, match="expected 5 scores"):
+        songeval.songeval_metric(
+            model_dict,
+            np.ones(24000, dtype=np.float32),
+            fs=24000,
+        )
+
+
+def test_songeval_metric_forwards_local_and_offline_configuration(monkeypatch):
+    calls = {}
+
+    def fake_setup(**kwargs):
+        calls.update(kwargs)
+        return {
+            "device": "cpu",
+            "model": DummySongEvalModel(),
+            "muq": DummyMuQ(),
+        }
+
+    monkeypatch.setattr(songeval, "songeval_model_setup", fake_setup)
+
+    songeval.SongEvalMetric(
+        {
+            "cache_dir": "cache-root",
+            "model_dir": "local-songeval",
+            "muq_model": "local-muq",
+            "offline": True,
+            "use_gpu": True,
+        }
+    )
+
+    assert calls == {
+        "cache_dir": "cache-root",
+        "model_dir": "local-songeval",
+        "muq_model": "local-muq",
+        "offline": True,
+        "use_gpu": True,
+    }
+
+
+def test_songeval_offline_mode_requires_local_assets(tmp_path):
+    with pytest.raises(FileNotFoundError, match="assets are not installed"):
+        songeval._resolve_songeval_dir(tmp_path, offline=True)
+
+
+def test_songeval_downloads_and_pins_missing_assets(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(command, check):
+        assert check
+        calls.append(command)
+        if command[1] == "clone":
+            model_dir = tmp_path / "SongEval"
+            (model_dir / "ckpt").mkdir(parents=True)
+            (model_dir / "model.py").touch()
+            (model_dir / "config.yaml").touch()
+            (model_dir / "ckpt" / "model.safetensors").touch()
+
+    monkeypatch.setattr(songeval.subprocess, "run", fake_run)
+
+    assert songeval._resolve_songeval_dir(tmp_path) == tmp_path / "SongEval"
+    assert calls == [
+        [
+            "git",
+            "clone",
+            songeval.SONGEVAL_REPOSITORY,
+            str(tmp_path / "SongEval"),
+        ],
+        [
+            "git",
+            "-C",
+            str(tmp_path / "SongEval"),
+            "checkout",
+            "--detach",
+            songeval.SONGEVAL_REVISION,
+        ],
+    ]
+
+
+def test_songeval_resolves_complete_local_assets(tmp_path):
+    model_dir = tmp_path / "custom-songeval"
+    (model_dir / "ckpt").mkdir(parents=True)
+    (model_dir / "model.py").touch()
+    (model_dir / "config.yaml").touch()
+    (model_dir / "ckpt" / "model.safetensors").touch()
+
+    assert songeval._resolve_songeval_dir(tmp_path, model_dir) == model_dir
+
+
+def test_songeval_setup_loads_local_assets_without_generic_model_import(
+    monkeypatch, tmp_path
+):
+    existing_generic_model = sys.modules.get("model")
+    model_dir = tmp_path / "SongEval"
+    (model_dir / "ckpt").mkdir(parents=True)
+    (model_dir / "model.py").write_text(
+        "import torch\n"
+        "class Generator(torch.nn.Module):\n"
+        "    def __init__(self, num_classes):\n"
+        "        super().__init__()\n"
+        "        self.bias = torch.nn.Parameter(torch.zeros(num_classes))\n"
+        "    def forward(self, hidden):\n"
+        "        return self.bias.unsqueeze(0)\n",
+        encoding="utf-8",
+    )
+    (model_dir / "config.yaml").write_text("placeholder", encoding="utf-8")
+    (model_dir / "ckpt" / "model.safetensors").touch()
+    muq_dir = tmp_path / "muq"
+    muq_dir.mkdir()
+
+    class FakeOmegaConf:
+        @staticmethod
+        def load(path):
+            return SimpleNamespace(
+                generator={"_target_": "model.Generator", "num_classes": 5}
+            )
+
+        @staticmethod
+        def to_container(config, resolve=True):
+            assert resolve
+            return dict(config)
+
+    class FakeMuQ:
+        requested_path = None
+        requested_kwargs = None
+
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            cls.requested_path = path
+            cls.requested_kwargs = kwargs
+            return cls()
+
+        def to(self, device):
+            return self
+
+        def eval(self):
+            return self
+
+    monkeypatch.setattr(songeval, "OmegaConf", FakeOmegaConf)
+    monkeypatch.setattr(songeval, "MuQ", FakeMuQ)
+    monkeypatch.setattr(
+        songeval,
+        "load_file",
+        lambda path, device: {"bias": torch.zeros(5)},
+    )
+
+    model_dict = songeval.songeval_model_setup(
+        cache_dir=tmp_path,
+        model_dir=model_dir,
+        muq_model=muq_dir,
+        offline=True,
+    )
+
+    assert model_dict["device"] == "cpu"
+    assert type(model_dict["model"]).__module__.startswith("_versa_songeval_model_")
+    assert FakeMuQ.requested_path == str(muq_dir)
+    assert FakeMuQ.requested_kwargs == {
+        "cache_dir": tmp_path / "huggingface",
+        "local_files_only": True,
+    }
+    assert sys.modules.get("model") is existing_generic_model
+
+
 def test_songeval_registration_metadata():
     registry = MetricRegistry()
 
@@ -71,6 +292,8 @@ def test_songeval_registration_metadata():
     assert not metadata.requires_reference
     assert metadata.gpu_compatible
     assert not metadata.auto_install
+    assert "einops" in metadata.dependencies
+    assert "hydra" not in metadata.dependencies
     assert registry.get_metric("SongEval") is songeval.SongEvalMetric
 
 

--- a/test/test_pipeline/test_speaking_rate.py
+++ b/test/test_pipeline/test_speaking_rate.py
@@ -23,7 +23,7 @@ class DummyWhisperModel:
 
 class DummyWhisper:
     @staticmethod
-    def load_model(model_tag, device="cpu"):
+    def load_model(model_tag, device="cpu", download_root=None):
         return DummyWhisperModel()
 
 

--- a/tools/install_songeval.sh
+++ b/tools/install_songeval.sh
@@ -6,17 +6,34 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PYTHON_BIN="${PYTHON:-python}"
 SONGEVAL_DIR="$REPO_ROOT/versa_cache/SongEval"
+SONGEVAL_REPO="https://github.com/ASLP-lab/SongEval.git"
+SONGEVAL_REVISION="848fb2ff3a2a9d64dcb20d46f07238c28abd7add"
 
 cd "$REPO_ROOT"
 
 "$PYTHON_BIN" -m pip install \
+    "einops" \
     "muq==0.1.0" \
-    "hydra-core==1.3.2" \
+    "omegaconf>=2.3,<3" \
     "safetensors"
 
 if [ ! -d "$SONGEVAL_DIR" ]; then
-    git clone https://github.com/ASLP-lab/SongEval.git "$SONGEVAL_DIR"
+    git clone "$SONGEVAL_REPO" "$SONGEVAL_DIR"
+elif [ ! -d "$SONGEVAL_DIR/.git" ]; then
+    echo "ERROR: $SONGEVAL_DIR exists but is not a Git checkout."
+    echo "Move it aside or provide that directory through the metric's model_dir option."
+    exit 1
 fi
+
+if [ -n "$(git -C "$SONGEVAL_DIR" status --porcelain)" ]; then
+    echo "ERROR: $SONGEVAL_DIR has local changes; refusing to change its revision."
+    exit 1
+fi
+
+if ! git -C "$SONGEVAL_DIR" cat-file -e "$SONGEVAL_REVISION^{commit}"; then
+    git -C "$SONGEVAL_DIR" fetch origin main
+fi
+git -C "$SONGEVAL_DIR" checkout --detach "$SONGEVAL_REVISION"
 
 if [ ! -f "$SONGEVAL_DIR/config.yaml" ]; then
     echo "ERROR: SongEval config.yaml is missing from $SONGEVAL_DIR."
@@ -29,4 +46,4 @@ if [ ! -f "$SONGEVAL_DIR/ckpt/model.safetensors" ]; then
     exit 1
 fi
 
-echo "SongEval dependencies, config, and checkpoint are ready."
+echo "SongEval dependencies and pinned assets ($SONGEVAL_REVISION) are ready."

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -220,6 +220,8 @@ def main():
     from versa.definition import MetricCategory
     from versa.scorer_shared import (
         audio_loader_setup,
+        configure_metric_cache_dirs,
+        configure_shared_cache_environment,
         VersaScorer,
         compute_summary,
     )
@@ -253,6 +255,8 @@ def main():
 
     with open(args.score_config, "r", encoding="utf-8") as f:
         score_config = yaml.safe_load(f)
+    configure_shared_cache_environment(args.cache_folder)
+    score_config = configure_metric_cache_dirs(score_config, args.cache_folder)
 
     # Validate before any scoring or model setup begins.
     scorer = VersaScorer()

--- a/versa/bin/scorer_chunk.py
+++ b/versa/bin/scorer_chunk.py
@@ -19,6 +19,8 @@ from versa.definition import MetricCategory
 from versa.config_validation import validate_score_config
 from versa.scorer_shared import (
     audio_loader_setup,
+    configure_metric_cache_dirs,
+    configure_shared_cache_environment,
     list_scoring,
     load_audio,
     load_score_modules,
@@ -324,6 +326,8 @@ def main():
 
     with open(args.score_config, "r", encoding="utf-8") as f:
         score_config = yaml.safe_load(f)
+    configure_shared_cache_environment(args.cache_folder)
+    score_config = configure_metric_cache_dirs(score_config, args.cache_folder)
 
     scorer = VersaScorer()
     try:
@@ -408,8 +412,6 @@ def main():
             continue
         corpus_config = dict(config)
         corpus_config.setdefault("io", args.io)
-        if args.cache_folder and "cache_dir" not in corpus_config:
-            corpus_config["cache_dir"] = str(Path(args.cache_folder) / config["name"])
         corpus_score_config.append(corpus_config)
 
     corpus_score_modules = scorer.load_metrics(

--- a/versa/corpus_metrics/nemo_wer.py
+++ b/versa/corpus_metrics/nemo_wer.py
@@ -32,7 +32,12 @@ except ImportError:
 TARGET_FS = 16000
 
 
-def nemo_wer_setup(model_tag="default", text_cleaner="whisper_basic", use_gpu=True):
+def nemo_wer_setup(
+    model_tag="default",
+    text_cleaner="whisper_basic",
+    use_gpu=True,
+    cache_dir="versa_cache/nemo",
+):
     if model_tag == "default":
         model_tag = "nvidia/stt_en_conformer_transducer_xlarge"
     device = "cuda" if use_gpu else "cpu"
@@ -43,6 +48,7 @@ def nemo_wer_setup(model_tag="default", text_cleaner="whisper_basic", use_gpu=Tr
     if TextCleaner is None:
         raise ImportError("nemo_wer requires espnet TextCleaner")
 
+    os.environ["NEMO_CACHE_DIR"] = str(cache_dir)
     asr_model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(model_tag)
     asr_model = asr_model.to(device)
     textcleaner = TextCleaner(text_cleaner)
@@ -146,10 +152,12 @@ class NemoWerMetric(BaseMetric):
         self.model_tag = self.config.get("model_tag", "default")
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
         self.use_gpu = self.config.get("use_gpu", True)
+        self.cache_dir = self.config.get("cache_dir", "versa_cache/nemo")
         self.wer_utils = nemo_wer_setup(
             model_tag=self.model_tag,
             text_cleaner=self.text_cleaner,
             use_gpu=self.use_gpu,
+            cache_dir=self.cache_dir,
         )
 
     def compute(self, predictions, references=None, metadata=None):

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -13,6 +13,7 @@ import kaldiio
 import soundfile as sf
 import yaml
 from numbers import Real
+from pathlib import Path
 from typing import Dict, List, Optional, Any, Union
 from tqdm import tqdm
 
@@ -121,6 +122,84 @@ def load_score_modules(
         use_gt_text=use_gt_text,
         use_gpu=use_gpu,
     )
+
+
+def _metric_cache_namespace(metric_name):
+    """Return a collision-safe shared namespace for a registered metric."""
+    name = str(metric_name).lower()
+    if name.startswith(("qwen2_audio_", "qwen_omni_")) or name in {
+        "hubert_wer",
+        "pam",
+    }:
+        return "huggingface"
+    if name in {"asr_matching", "speaking_rate", "whisper_wer"}:
+        return "whisper"
+    if name in {
+        "arecho",
+        "espnet_wer",
+        "owsm_lid",
+        "owsm_wer",
+        "se_snr",
+        "speaker",
+        "universa",
+    }:
+        return "espnet_model_zoo"
+    if name in {
+        "multigauss",
+        "pseudo_mos",
+        "sheet_ssqa",
+        "squim_no_ref",
+        "squim_ref",
+        "vad",
+    }:
+        return "torch"
+    return name
+
+
+def configure_metric_cache_dirs(score_config, cache_folder=None):
+    """Apply a shared cache root without overriding metric-specific settings.
+
+    Metrics backed by the same model hub receive a shared namespace. Other
+    metrics receive their own directory so unrelated intermediate files cannot
+    collide. Configurations that already declare ``cache_dir`` remain
+    authoritative.
+    """
+    if cache_folder is None:
+        return score_config
+
+    cache_root = Path(cache_folder).expanduser()
+    return [
+        {
+            **config,
+            "cache_dir": config.get(
+                "cache_dir",
+                str(cache_root / _metric_cache_namespace(config["name"])),
+            ),
+        }
+        for config in score_config
+    ]
+
+
+def configure_shared_cache_environment(cache_folder=None):
+    """Point common model hubs at a single shareable cache root."""
+    if cache_folder is None:
+        return None
+
+    cache_root = Path(cache_folder).expanduser().resolve()
+    hf_cache = cache_root / "huggingface"
+    torch_cache = cache_root / "torch"
+    cache_root.mkdir(parents=True, exist_ok=True)
+
+    os.environ["VERSA_CACHE_DIR"] = str(cache_root)
+    os.environ["VERSA_HF_CACHE_DIR"] = str(hf_cache)
+    os.environ["HF_HOME"] = str(hf_cache)
+    os.environ["HF_HUB_CACHE"] = str(hf_cache)
+    os.environ["TRANSFORMERS_CACHE"] = str(hf_cache)
+    os.environ["HF_DATASETS_CACHE"] = str(hf_cache / "datasets")
+    os.environ["TORCH_HOME"] = str(torch_cache)
+    os.environ["NEMO_CACHE_DIR"] = str(cache_root / "nemo")
+    os.environ["XDG_CACHE_HOME"] = str(cache_root)
+    return cache_root
 
 
 def list_scoring(

--- a/versa/utterance_metrics/arecho.py
+++ b/versa/utterance_metrics/arecho.py
@@ -11,7 +11,9 @@ import soundfile as sf
 from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
 
 
-def arecho_model_setup(model_tag="default", use_gpu=False):
+def arecho_model_setup(
+    model_tag="default", use_gpu=False, cache_dir="versa_cache/espnet_model_zoo"
+):
     """
     Setup ARECHO model for inference.
 
@@ -54,8 +56,14 @@ def arecho_model_setup(model_tag="default", use_gpu=False):
     # Set device
     device = "cuda" if use_gpu and torch.cuda.is_available() else "cpu"
 
-    # Load the model
-    model = UniversaInference.from_pretrained(model_name, device=device)
+    try:
+        from espnet_model_zoo.downloader import ModelDownloader
+    except ImportError:
+        raise ImportError(
+            "arecho requires espnet_model_zoo. Please install it and retry"
+        )
+    model_kwargs = ModelDownloader(cachedir=cache_dir).download_and_unpack(model_name)
+    model = UniversaInference(device=device, **model_kwargs)
 
     return model
 
@@ -152,9 +160,11 @@ class ArechoMetric(BaseMetric):
     def _setup(self):
         self.model_tag = self.config.get("model_tag", "default")
         self.use_gpu = self.config.get("use_gpu", False)
+        self.cache_dir = self.config.get("cache_dir", "versa_cache/espnet_model_zoo")
         self.model = arecho_model_setup(
             model_tag=self.model_tag,
             use_gpu=self.use_gpu,
+            cache_dir=self.cache_dir,
         )
 
     def compute(self, predictions, references=None, metadata=None):

--- a/versa/utterance_metrics/nomad.py
+++ b/versa/utterance_metrics/nomad.py
@@ -58,7 +58,10 @@ class NomadMetric(BaseMetric):
             )
 
         self.use_gpu = self.config.get("use_gpu", False)
-        self.cache_dir = self.config.get("model_cache", "versa_cache/nomad_pt-models")
+        self.cache_dir = self.config.get(
+            "cache_dir",
+            self.config.get("model_cache", "versa_cache/nomad_pt-models"),
+        )
 
         try:
             self.model = self._setup_model()

--- a/versa/utterance_metrics/pam.py
+++ b/versa/utterance_metrics/pam.py
@@ -29,6 +29,7 @@ import numpy as np
 import torch.nn.functional as F
 
 from versa.definition import BaseMetric, MetricMetadata, MetricCategory, MetricType
+from versa.huggingface_cache import configure_huggingface_cache, get_hf_cache_dir
 
 # Handle optional dependencies
 try:
@@ -96,6 +97,7 @@ class PAM:
         model_fp: Optional[Union[Path, str]] = None,
         model_config: Optional[Dict[str, Any]] = None,
         use_cuda: bool = False,
+        cache_dir: Optional[Union[Path, str]] = None,
     ):
         """
         Initialize PAM model.
@@ -110,10 +112,11 @@ class PAM:
         self.device = torch.device(
             "cuda" if use_cuda and torch.cuda.is_available() else "cpu"
         )
+        self.cache_dir = cache_dir
 
         # Automatically download model if not provided
         if not model_fp:
-            model_fp = hf_hub_download(HF_REPO, CLAP_VERSION)
+            model_fp = hf_hub_download(HF_REPO, CLAP_VERSION, cache_dir=self.cache_dir)
 
         self.model_fp = model_fp
         self.use_cuda = use_cuda
@@ -157,7 +160,9 @@ class PAM:
         clap.eval()  # set clap in eval mode
 
         # Setup tokenizer
-        tokenizer = AutoTokenizer.from_pretrained(args.text_model)
+        tokenizer = AutoTokenizer.from_pretrained(
+            args.text_model, cache_dir=self.cache_dir
+        )
         tokenizer.add_special_tokens({"pad_token": "!"})
 
         # Move model to appropriate device
@@ -280,7 +285,10 @@ class PamMetric(BaseMetric):
             )
 
         self.repro = self.config.get("repro", True)
-        self.cache_dir = self.config.get("cache_dir", "versa_cache/pam")
+        self.cache_dir = get_hf_cache_dir(
+            self.config.get("cache_dir", "versa_cache/pam")
+        )
+        configure_huggingface_cache(self.cache_dir)
         self.use_gpu = self.config.get("use_gpu", False)
 
         # Extract model configuration from config
@@ -306,7 +314,11 @@ class PamMetric(BaseMetric):
         }
 
         try:
-            self.model = PAM(model_config=model_config, use_cuda=self.use_gpu)
+            self.model = PAM(
+                model_config=model_config,
+                use_cuda=self.use_gpu,
+                cache_dir=self.cache_dir,
+            )
         except Exception as e:
             raise RuntimeError(f"Failed to initialize PAM model: {str(e)}") from e
 

--- a/versa/utterance_metrics/qwen2_audio.py
+++ b/versa/utterance_metrics/qwen2_audio.py
@@ -285,6 +285,7 @@ Then, output only the predicted singing style from the list above.
 def qwen2_model_setup(
     model_tag: str = "Qwen/Qwen2-Audio-7B-Instruct",
     start_prompt: str = "The following is a conversation with an AI assistant. The assistant is helpful, honest, and harmless.",
+    cache_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Set up the Qwen2-Audio model for speech analysis.
 
@@ -301,9 +302,9 @@ def qwen2_model_setup(
         raise RuntimeError(
             "Qwen2Audio is used for evaluation while transformers is not installed (could be a version issue)."
         )
-    processor = AutoProcessor.from_pretrained(model_tag)
+    processor = AutoProcessor.from_pretrained(model_tag, cache_dir=cache_dir)
     model = Qwen2AudioForConditionalGeneration.from_pretrained(
-        model_tag, device_map="auto"
+        model_tag, device_map="auto", cache_dir=cache_dir
     )
 
     start_conversation = [
@@ -466,9 +467,11 @@ class Qwen2AudioMetric(BaseMetric):
             raise ValueError("metric_name must be provided")
         self.prompt = self.config.get("prompt")
         self.max_length = self.config.get("max_length", 1000)
+        self.cache_dir = self.config.get("cache_dir")
         self.qwen_utils = qwen2_model_setup(
             model_tag=self.model_tag,
             start_prompt=self.start_prompt,
+            cache_dir=self.cache_dir,
         )
 
     def compute(self, predictions, references=None, metadata=None):

--- a/versa/utterance_metrics/qwen_omni.py
+++ b/versa/utterance_metrics/qwen_omni.py
@@ -85,6 +85,7 @@ def qwen_omni_model_setup(
     start_prompt: str = "The following is a conversation with an AI assistant. The assistant is helpful, honest, and harmless.",
     use_gpu: bool = True,
     device_map: Optional[str] = None,
+    cache_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Set up the Qwen2-Audio model for speech analysis.
 
@@ -103,11 +104,12 @@ def qwen_omni_model_setup(
         )
     target_device = "cuda" if use_gpu and torch.cuda.is_available() else "cpu"
     device_map = device_map or target_device
-    processor = Qwen2_5OmniProcessor.from_pretrained(model_tag)
+    processor = Qwen2_5OmniProcessor.from_pretrained(model_tag, cache_dir=cache_dir)
     model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
         model_tag,
         torch_dtype="auto",
         device_map=device_map,
+        cache_dir=cache_dir,
         # attn_implementation="flash_attention_2", NOTE(jiatong): to add
     )
     if device_map in {None, "cpu", "cuda"}:
@@ -280,11 +282,13 @@ class QwenOmniMetric(BaseMetric):
         self.max_length = self.config.get("max_length", 500)
         self.use_gpu = self.config.get("use_gpu", True)
         self.device_map = self.config.get("device_map")
+        self.cache_dir = self.config.get("cache_dir")
         self.qwen_utils = qwen_omni_model_setup(
             model_tag=self.model_tag,
             start_prompt=self.start_prompt,
             use_gpu=self.use_gpu,
             device_map=self.device_map,
+            cache_dir=self.cache_dir,
         )
 
     def compute(self, predictions, references=None, metadata=None):

--- a/versa/utterance_metrics/songeval.py
+++ b/versa/utterance_metrics/songeval.py
@@ -1,18 +1,16 @@
-import numpy as np
+import importlib.util
+import hashlib
 import logging
 import subprocess
 import sys
 from pathlib import Path
 
+import numpy as np
 import torch
 
 from versa.audio_utils import resample_audio
 from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
-
-try:
-    from hydra.utils import instantiate
-except ImportError:
-    instantiate = None
+from versa.huggingface_cache import get_hf_cache_dir
 
 try:
     from muq import MuQ
@@ -33,6 +31,9 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 TARGET_SAMPLE_RATE = 24000
+DEFAULT_MUQ_MODEL = "OpenMuQ/MuQ-large-msd-iter"
+SONGEVAL_REPOSITORY = "https://github.com/ASLP-lab/SongEval.git"
+SONGEVAL_REVISION = "848fb2ff3a2a9d64dcb20d46f07238c28abd7add"
 SONGEVAL_OUTPUTS = (
     ("songeval_coherence", "Coherence"),
     ("songeval_musicality", "Musicality"),
@@ -44,8 +45,6 @@ SONGEVAL_OUTPUTS = (
 
 def _require_songeval_dependencies():
     missing = []
-    if instantiate is None:
-        missing.append("hydra-core")
     if MuQ is None:
         missing.append("muq")
     if OmegaConf is None:
@@ -60,44 +59,135 @@ def _require_songeval_dependencies():
         )
 
 
-def songeval_model_setup(cache_dir="versa_cache", use_gpu=False):
+def _required_songeval_files(songeval_dir):
+    return (
+        songeval_dir / "model.py",
+        songeval_dir / "config.yaml",
+        songeval_dir / "ckpt" / "model.safetensors",
+    )
+
+
+def _resolve_songeval_dir(cache_dir, model_dir=None, offline=False):
+    songeval_dir = Path(model_dir) if model_dir else Path(cache_dir) / "SongEval"
+    missing_files = [
+        str(path)
+        for path in _required_songeval_files(songeval_dir)
+        if not path.is_file()
+    ]
+    if (
+        missing_files
+        and model_dir is None
+        and not offline
+        and not songeval_dir.exists()
+    ):
+        songeval_dir.parent.mkdir(parents=True, exist_ok=True)
+        logger.info("Downloading SongEval into %s", songeval_dir)
+        subprocess.run(
+            ["git", "clone", SONGEVAL_REPOSITORY, str(songeval_dir)], check=True
+        )
+        subprocess.run(
+            [
+                "git",
+                "-C",
+                str(songeval_dir),
+                "checkout",
+                "--detach",
+                SONGEVAL_REVISION,
+            ],
+            check=True,
+        )
+        missing_files = [
+            str(path)
+            for path in _required_songeval_files(songeval_dir)
+            if not path.is_file()
+        ]
+
+    if missing_files:
+        raise FileNotFoundError(
+            "SongEval assets are not installed or are incomplete. Missing: {}. "
+            "Run `tools/install_songeval.sh`, or set `model_dir` to a complete "
+            "local SongEval checkout.".format(", ".join(missing_files))
+        )
+    return songeval_dir
+
+
+def _load_generator_class(songeval_dir):
+    """Load upstream's Generator without exposing its generic `model` module name."""
+    module_path = (songeval_dir / "model.py").resolve()
+    module_digest = hashlib.sha256(str(module_path).encode("utf-8")).hexdigest()[:12]
+    module_name = f"_versa_songeval_model_{module_digest}"
+    module = sys.modules.get(module_name)
+    if module is None:
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        if spec is None or spec.loader is None:
+            raise ImportError(
+                f"Unable to import SongEval model code from {module_path}"
+            )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        try:
+            spec.loader.exec_module(module)
+        except Exception:
+            sys.modules.pop(module_name, None)
+            raise
+
+    try:
+        return module.Generator
+    except AttributeError as error:
+        raise ImportError(
+            f"SongEval model module {module_path} does not define Generator"
+        ) from error
+
+
+def songeval_model_setup(
+    cache_dir="versa_cache",
+    use_gpu=False,
+    model_dir=None,
+    muq_model=DEFAULT_MUQ_MODEL,
+    offline=False,
+):
     """Set up SongEval classifier and MuQ encoder."""
     _require_songeval_dependencies()
     device = "cuda" if use_gpu and torch.cuda.is_available() else "cpu"
+    if use_gpu and device == "cpu":
+        logger.warning(
+            "SongEval requested GPU execution, but CUDA is unavailable; using CPU"
+        )
 
-    cache_dir = Path(cache_dir)
-    cache_dir.mkdir(parents=True, exist_ok=True)
-
-    repo_url = "https://github.com/ASLP-lab/SongEval.git"
-
-    songeval_dir = cache_dir / "SongEval"
-
-    if not songeval_dir.exists():
-        logger.info(f"Cloning SongEval repository into {cache_dir}")
-        subprocess.run(["git", "clone", repo_url, str(songeval_dir)], check=True)
-    else:
-        logger.info(f"Using existing SongEval repository in {cache_dir}")
-
-    songeval_path = str(songeval_dir)
-    if songeval_path not in sys.path:
-        sys.path.insert(0, songeval_path)
+    songeval_dir = _resolve_songeval_dir(cache_dir, model_dir, offline=offline)
+    logger.info("Using SongEval assets in %s", songeval_dir)
 
     model_path = songeval_dir / "ckpt" / "model.safetensors"
     config_path = songeval_dir / "config.yaml"
 
-    if not model_path.exists():
-        raise FileNotFoundError(f"Model file not found in {model_path}")
-    if not config_path.exists():
-        raise FileNotFoundError(f"Config file not found in {config_path}")
-
     with torch.no_grad():
         train_config = OmegaConf.load(config_path)
-        model = instantiate(train_config.generator)
+        generator_config = OmegaConf.to_container(train_config.generator, resolve=True)
+        target = generator_config.pop("_target_", None)
+        if target != "model.Generator":
+            raise ValueError(
+                "Unsupported SongEval generator target {!r}; expected "
+                "'model.Generator' from pinned revision {}".format(
+                    target, SONGEVAL_REVISION
+                )
+            )
+        generator_class = _load_generator_class(songeval_dir)
+        model = generator_class(**generator_config)
         state_dict = load_file(model_path, device="cpu")
         model.load_state_dict(state_dict, strict=False)
         model = model.to(device).eval()
 
-    muq_model = MuQ.from_pretrained("OpenMuQ/MuQ-large-msd-iter")
+    if offline and not Path(muq_model).is_dir():
+        raise FileNotFoundError(
+            "SongEval offline mode requires `muq_model` to point to a local "
+            f"MuQ model directory; got {muq_model!r}"
+        )
+    muq_cache_dir = Path(get_hf_cache_dir(Path(cache_dir) / "huggingface"))
+    muq_model = MuQ.from_pretrained(
+        str(muq_model),
+        cache_dir=muq_cache_dir,
+        local_files_only=offline,
+    )
     muq_model = muq_model.to(device).eval()
 
     model_dict = {"model": model, "muq": muq_model, "device": device}
@@ -114,13 +204,46 @@ def songeval_metric(model_dict, pred, fs):
     model = model_dict["model"]
     muq_model = model_dict["muq"]
 
-    pred = resample_audio(pred, fs, TARGET_SAMPLE_RATE)
+    if not isinstance(fs, (int, np.integer)) or fs <= 0:
+        raise ValueError(f"Sample rate must be a positive integer; got {fs!r}")
+
+    pred = np.asarray(pred)
+    if pred.ndim == 2:
+        if pred.shape[1] <= 8:
+            pred = pred.mean(axis=1)
+        elif pred.shape[0] <= 8:
+            pred = pred.mean(axis=0)
+        else:
+            raise ValueError(
+                "SongEval received ambiguous 2-D audio; expected samples x channels "
+                "or channels x samples with at most 8 channels"
+            )
+    if pred.ndim != 1:
+        raise ValueError(f"SongEval expects mono audio; got shape {pred.shape}")
+    if pred.size == 0:
+        raise ValueError("SongEval requires non-empty audio")
+    if not np.isfinite(pred).all():
+        raise ValueError("SongEval audio contains NaN or infinite values")
+
+    pred = resample_audio(pred, int(fs), TARGET_SAMPLE_RATE)
 
     audio = torch.as_tensor(pred, dtype=torch.float32, device=device).unsqueeze(0)
     with torch.no_grad():
         output = muq_model(audio, output_hidden_states=True)
-        hidden = output["hidden_states"][6]
+        try:
+            hidden = output["hidden_states"][6]
+        except (KeyError, IndexError, TypeError) as error:
+            raise RuntimeError(
+                "MuQ output does not contain the expected hidden state at layer 6"
+            ) from error
         scores_g = model(hidden).squeeze(0)
+
+    if scores_g.ndim != 1 or scores_g.numel() != len(SONGEVAL_OUTPUTS):
+        raise RuntimeError(
+            "SongEval predictor returned shape {}; expected {} scores".format(
+                tuple(scores_g.shape), len(SONGEVAL_OUTPUTS)
+            )
+        )
 
     values = {}
     for index, (output_key, _) in enumerate(SONGEVAL_OUTPUTS):
@@ -135,9 +258,15 @@ class SongEvalMetric(BaseMetric):
     def _setup(self):
         self.cache_dir = self.config.get("cache_dir", "versa_cache")
         self.use_gpu = self.config.get("use_gpu", False)
+        self.model_dir = self.config.get("model_dir")
+        self.muq_model = self.config.get("muq_model", DEFAULT_MUQ_MODEL)
+        self.offline = self.config.get("offline", False)
         self.model_dict = songeval_model_setup(
             cache_dir=self.cache_dir,
             use_gpu=self.use_gpu,
+            model_dir=self.model_dir,
+            muq_model=self.muq_model,
+            offline=self.offline,
         )
 
     def compute(self, predictions, references=None, metadata=None):
@@ -161,7 +290,7 @@ def _songeval_metadata():
         gpu_compatible=True,
         auto_install=False,
         dependencies=[
-            "hydra",
+            "einops",
             "muq",
             "numpy",
             "omegaconf",

--- a/versa/utterance_metrics/speaking_rate.py
+++ b/versa/utterance_metrics/speaking_rate.py
@@ -33,7 +33,11 @@ CHUNK_SIZE = 30  # seconds
 
 
 def speaking_rate_model_setup(
-    model_tag="default", beam_size=5, text_cleaner="whisper_basic", use_gpu=True
+    model_tag="default",
+    beam_size=5,
+    text_cleaner="whisper_basic",
+    use_gpu=True,
+    cache_dir="versa_cache/whisper",
 ):
     if model_tag == "default":
         model_tag = "large"
@@ -47,7 +51,7 @@ def speaking_rate_model_setup(
         raise ImportError(
             "speaking_rate requires espnet TextCleaner. Please install espnet"
         )
-    model = whisper.load_model(model_tag, device=device)
+    model = whisper.load_model(model_tag, device=device, download_root=cache_dir)
     textcleaner = TextCleaner(text_cleaner)
     wer_utils = {"model": model, "cleaner": textcleaner, "beam_size": beam_size}
     return wer_utils
@@ -97,11 +101,13 @@ class SpeakingRateMetric(BaseMetric):
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
         self.use_gpu = self.config.get("use_gpu", True)
         self.use_char = self.config.get("use_char", False)
+        self.cache_dir = self.config.get("cache_dir", "versa_cache/whisper")
         self.wer_utils = speaking_rate_model_setup(
             model_tag=self.model_tag,
             beam_size=self.beam_size,
             text_cleaner=self.text_cleaner,
             use_gpu=self.use_gpu,
+            cache_dir=self.cache_dir,
         )
 
     def compute(self, predictions, references=None, metadata=None):

--- a/versa/utterance_metrics/squim.py
+++ b/versa/utterance_metrics/squim.py
@@ -85,6 +85,8 @@ class SquimMetric(BaseMetric):
                 "SQUIM is not available. Please install pesq, pystoi, and torchaudio"
             )
         self.mode = self.config.get("mode", "no_ref")
+        self.cache_dir = self.config.get("cache_dir", "versa_cache/torch")
+        torch.hub.set_dir(self.cache_dir)
         if self.mode not in {"ref", "no_ref"}:
             raise ValueError(f"Invalid SQUIM mode: {self.mode}")
         if self.mode == "ref":

--- a/versa/utterance_metrics/vad.py
+++ b/versa/utterance_metrics/vad.py
@@ -19,8 +19,9 @@ def vad_model_setup(
     speech_pad_ms=30,
     trust_repo=True,
     force_reload=False,
+    cache_dir="versa_cache/torch",
 ):
-
+    torch.hub.set_dir(cache_dir)
     hub_kwargs = {
         "repo_or_dir": "snakers4/silero-vad",
         "model": "silero_vad",
@@ -79,6 +80,7 @@ class VadMetric(BaseMetric):
         self.speech_pad_ms = self.config.get("speech_pad_ms", 30)
         self.trust_repo = self.config.get("trust_repo", True)
         self.force_reload = self.config.get("force_reload", False)
+        self.cache_dir = self.config.get("cache_dir", "versa_cache/torch")
         self.model_info = vad_model_setup(
             threshold=self.threshold,
             min_speech_duration_ms=self.min_speech_duration_ms,
@@ -87,6 +89,7 @@ class VadMetric(BaseMetric):
             speech_pad_ms=self.speech_pad_ms,
             trust_repo=self.trust_repo,
             force_reload=self.force_reload,
+            cache_dir=self.cache_dir,
         )
 
     def compute(self, predictions, references=None, metadata=None):


### PR DESCRIPTION
## Summary

- add production-ready SongEval support with pinned upstream assets, optional dependencies, local/offline configuration, audio validation, and stable result keys
- make `--cache_folder` consistently configure utterance and corpus metrics in both scorer entry points
- share model caches by backend for Hugging Face, Whisper, ESPnet, Torch Hub, and NeMo while preserving explicit metric `cache_dir` overrides
- route cache settings through existing model-backed metrics including ARECHO, NeMo WER, NOMAD, PAM, Qwen2-Audio, Qwen2.5-Omni, speaking rate, SQUIM, and VAD
- document the shared-cache layout and add focused regression coverage

## Motivation

Versa exposed cache options in several places, but the main scorer did not apply `--cache_folder` to ordinary utterance metrics and some pretrained-model loaders ignored metric cache configuration. This could duplicate large checkpoints or place downloads in user-specific default locations. SongEval also needed a reliable setup path for both its predictor and MuQ encoder.

This change makes a mounted cache root reusable across runs and machines while keeping unrelated metric artifacts isolated.

## Validation

- `132 passed, 1 skipped` across metric definitions, base metric/pipeline coverage, SongEval, shared-cache routing, NOMAD, PAM cache forwarding, and speaking-rate tests
- Black checks pass for all changed Python files
- `bash -n tools/install_songeval.sh`
- `git diff --check`
- wheel build with `pip wheel . --no-deps --no-build-isolation`
- real SongEval + MuQ CPU inference:
  `VERSA_RUN_REAL_MODEL_TESTS=1 python -m pytest test/test_metrics/test_songeval.py::test_songeval_real_model_inference -vv -s`
  (`1 passed` in 43.04 seconds)

The real-model test remains opt-in because it downloads approximately 8.5 GB
of MuQ assets in addition to the SongEval checkpoint.
