### PR TITLE
docs: fix broken links in supported_metrics and users

### DIFF
--- a/docs/supported_metrics.md
+++ b/docs/supported_metrics.md
@@ -87,10 +87,10 @@ We include x mark if the metric is auto-installed in versa.
 | 17 | x | Log-Weighted Mean Square Error | log_wmse | log_wmse |[log_wmse](https://github.com/nomonosound/log-wmse-audio-quality) |
 | 18 | x | ASR-oriented Mismatch Error Rate (ASR-Mismatch) | asr_match | asr_match_error_rate | - | - |
 | 19 |   | Virtual Speech Quality Objective Listener (VISQOL)  | visqol | visqol | [google-visqol](https://github.com/google/visqol) | [paper](https://arxiv.org/abs/2004.09584) |
-| 20 |  | Frequency-Weighted SEGmental SNR (FWSEGSNR) | pysepm | pysepm_fwsegsnr | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://ecs.utdallas.edu/loizou/speech/obj_paper_jan08.pdf)|
-| 21 |  | Weighted Spectral Slope (WSS) | pysepm | pysepm_wss | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://ecs.utdallas.edu/loizou/speech/obj_paper_jan08.pdf)|
+| 20 |  | Frequency-Weighted SEGmental SNR (FWSEGSNR) | pysepm | pysepm_fwsegsnr | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://doi.org/10.1109/TASL.2007.911054)|
+| 21 |  | Weighted Spectral Slope (WSS) | pysepm | pysepm_wss | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://doi.org/10.1109/TASL.2007.911054)|
 | 22 |  | Cepstrum Distance Objective Speech Quality Measure (CD) | pysepm | pysepm_cd | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://ieeexplore.ieee.org/document/407206)|
-| 23 |  | Composite Objective Speech Quality (composite) | pysepm | pysepm_Csig, pysepm_Cbak, pysepm_Covl | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://ecs.utdallas.edu/loizou/speech/obj_paper_jan08.pdf)|
+| 23 |  | Composite Objective Speech Quality (composite) | pysepm | pysepm_Csig, pysepm_Cbak, pysepm_Covl | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://doi.org/10.1109/TASL.2007.911054)|
 | 24 |  | Coherence and speech intelligibility index (CSII) | pysepm | pysepm_csii_high, pysepm_csii_mid, pysepm_csii_low | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://www.researchgate.net/profile/James-Kates-2/publication/7842209_Coherence_and_the_speech_intelligibility_index/links/546f5dab0cf2d67fc0310f88/Coherence-and-the-speech-intelligibility-index.pdf)|
 | 25 |  | Normalized-covariance measure (NCM) | pysepm | pysepm_ncm | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://pmc.ncbi.nlm.nih.gov/articles/PMC3037773/pdf/JASMAN-000128-003715_1.pdf)|
 | 26 | x | Uni-VERSA (Versatile Speech Assessment with a Unified Framework) with Paired Reference | universa | universa_{sub_metrics} | [Uni-VERSA](https://huggingface.co/collections/espnet/universa-6834e7c0a28225bffb6e2526) | [paper](https://arxiv.org/abs/2505.20741) |
@@ -116,7 +116,7 @@ We include x mark if the metric is auto-installed in versa.
 | 11 |   | NOMAD: Unsupervised Learning of Perceptual Embeddings For Speech Enhancement and Non-Matching Reference Audio Quality Assessment |  nomad | nomad |[Nomad](https://github.com/shimhz/nomad/tree/main) | [paper](https://arxiv.org/abs/2309.16284) |
 | 12 |   | Contrastive Language-Audio Pretraining Score (CLAP Score) | clap_score | clap_score | [frechet-audio-distance](https://github.com/gudgud96/frechet-audio-distance) | [paper](https://arxiv.org/abs/2301.12661) |
 | 13 |   | Accompaniment Prompt Adherence (APA) | apa | apa | [Sony-audio-metrics](https://github.com/SonyCSLParis/audio-metrics) | [paper](https://arxiv.org/abs/2404.00775) |
-| 14 |  | Log Likelihood Ratio (LLR) | pysepm | pysepm_llr | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://ecs.utdallas.edu/loizou/speech/obj_paper_jan08.pdf)|
+| 14 |  | Log Likelihood Ratio (LLR) | pysepm | pysepm_llr | [pysepm](https://github.com/shimhz/pysepm.git) | [Paper](https://doi.org/10.1109/TASL.2007.911054)|
 | 15 | x | Uni-VERSA (Versatile Speech Assessment with a Unified Framework) with Paired Text | universa | universa_{sub_metrics} | [Uni-VERSA](https://huggingface.co/collections/espnet/universa-6834e7c0a28225bffb6e2526) | [paper](https://arxiv.org/abs/2505.20741) |
 | 16 |  | Singer Embedding Similarity  | singer | singer_similarity | [SSL-Singer-Identity](https://github.com/SonyCSLParis/ssl-singer-identity) | [paper](https://hal.science/hal-04186048v1) |
 

--- a/docs/users.md
+++ b/docs/users.md
@@ -3,8 +3,8 @@
 
 | Category   | Title / Project | Venue / Year | How VERSA Was Used | Reference |
 |------------|-----------------|--------------|--------------------|------------|
-| **Toolkits** | ESPnet (TTS recipes) | Toolkit docs | “TTS eval using VERSA” section in official docs | [ESPnet TTS Docs](https://espnet.github.io/espnet/tts.html#evaluation) |
-|            | ESPnet-Codec | SLT2024 | Released together with VERSA for codec evaluation | [Paper PDF](https://arxiv.org/abs/2406.08061) · [GitHub](https://github.com/espnet/espnet/tree/master/egs2/codec) |
+| **Toolkits** | ESPnet (TTS recipes) | Toolkit docs | “TTS eval using VERSA” section in official docs | [ESPnet TTS Docs](https://github.com/espnet/espnet/tree/master/egs2/TEMPLATE/tts1#9-tts-eval-using-versa) |
+|            | ESPnet-Codec | SLT2024 | Released together with VERSA for codec evaluation | [Paper PDF](https://arxiv.org/abs/2406.08061) · [GitHub](https://github.com/espnet/espnet/tree/master/egs2/TEMPLATE/codec1) |
 |            | ESPnet-SpeechLM | NAACL2025 | Tables report results from VERSA evaluations | [Report PDF](https://arxiv.org/abs/2406.11059) |
 |            | ESPnet-SDS: Unified toolkit and demo for spoken dialogue systems | NAACL2025 | Using VERSA for speech synthesis evaluation | [Paper PDF](https://arxiv.org/pdf/2503.08533) |
 | **Papers** | TITW: Text-To-Speech in the Wild | Interspeech2025 | Used VERSA for MCD, UTMOS, DNSMOS, WER | [Paper PDF](https://arxiv.org/abs/2402.04354) |
@@ -20,7 +20,7 @@
 |            | OpusLM: A Family of Open Unified Speech Language Models | Interspeech2025 | Using VERSA for speech synthesis evaluation | [Paper PDF](https://arxiv.org/pdf/2506.17611) |
 | **Benchmarks / Challenges** | Uni-VERSA Benchmark | Interspeech2025 | Annotated dataset using VERSA (default config) | [Paper PDF](https://arxiv.org/abs/2505.03123) |
 |            | URGENT Challenge 2026 | ICASSP 2026 | Track 2 rules: evaluation derivatives over VERSA | [URGENT Rules](https://urgent-challenge.github.io/urgent2026/track2/#rules) |
-|            | CHiME-9 Challenge | ChiME 2025 | Task 2 rules reference VERSA-style evaluation pipeline | [CHiME-9 Rules](https://www.chimechallenge.org/current/task2/rules) |
+|            | CHiME-9 Challenge | ChiME 2025 | Task 2 rules reference VERSA-style evaluation pipeline | [CHiME-9 Rules](https://www.chimechallenge.org/challenges/chime9/task2/rules) |
 |            | LRAC Challenge | ICASSP 2026 | Rules build on VERSA metrics for low-resource audio codec evaluation | [LRAC Challenge](https://crowdsourcing.cisco.com/lrac-challenge/2025/) |
 |            | SVCC Challenge | 2025/26 | Expected adoption of VERSA for objective eval (not yet official announced) | [SVCC Site](https://www.vc-challenge.org/) |
 


### PR DESCRIPTION
Ran a link check over the docs while evaluating VERSA for my own audio-QA work and found 7 dead link occurrences across 2 files. All replacements checked by hand:

- The ESPnet TTS docs link (`espnet.github.io/espnet/tts.html#evaluation`) 404s since the ESPnet docs restructure — now points at the "TTS eval using versa" section of the `egs2/TEMPLATE/tts1` README.
- `egs2/codec` no longer exists in the ESPnet tree — now points at `egs2/TEMPLATE/codec1`.
- The CHiME-9 Task 2 rules URL moved — now `/challenges/chime9/task2/rules`.
- The four pysepm paper links (FWSEGSNR, WSS, composite, LLR) pointed at `ecs.utdallas.edu`, which no longer resolves — replaced with the paper's DOI (Hu & Loizou 2008, IEEE TASLP), which shouldn't rot.

No other changes.
