### PR TITLE
ci: update checkout and setup-python to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
         
@@ -38,10 +38,10 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
         
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
         
@@ -59,10 +59,10 @@ jobs:
     needs: install-tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
         
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.10'
         


### PR DESCRIPTION
Updates the CI workflow to use current GitHub-maintained action versions.

Changes:
- actions/checkout v4 -> v7 in all three jobs
- actions/setup-python v5 -> v7 in all three jobs

setup-python v7 dropped the pip-install input; this workflow does not use it, so no other changes were needed.

Validation:
- YAML parses locally (python yaml.safe_load)
- current refs resolved live from actions/checkout and actions/setup-python releases (v7.0.1, v7.0.0)

Scope: .github/workflows/ci.yml only.