### PR TITLE
Add optional MAPSS multi-source metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ On first use, VERSA downloads a pinned SongEval checkout into
 `versa_cache/SongEval` and MuQ into `versa_cache/huggingface`. For a fully local
 run, set `model_dir`, `muq_model`, and `offline: true` in the YAML.
 
+MAPSS is an optional multi-source metric for source-separation systems. Its
+backend supports Python 3.10--3.12 and constrains `transformers<4.53`, so install
+it in a compatible environment instead of adding it to the VERSA base install:
+
+```bash
+PYTHON=python tools/install_mapss.sh
+versa-score \
+    --score_config egs/separate_metrics/mapss.yaml \
+    --pred_sources estimates/source1.scp estimates/source2.scp \
+    --gt_sources references/source1.scp references/source2.scp \
+    --output_file mapss.jsonl \
+    --io soundfile \
+    --use_gpu
+```
+
+The SCP lists are positional: predicted source *i* must estimate reference
+source *i*, and every list must contain the same mixture keys. VERSA writes the
+diagnostic per-source means to JSONL and retains MAPSS's frame-level PS, PM, and
+confidence tables under `versa_cache/mapss/results`. The frame-level outputs
+should be retained for scientific reporting; the PS convenience mean is not the
+paper's formal utterance-level pooling protocol.
+
 If NLTK downloads fail with a certificate verification error, point Python at
 the certificate bundle used by `certifi` before running the tests:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -38,6 +38,7 @@ Every metric registration should include a `MetricMetadata` entry with:
   `DISTRIBUTIONAL`
 - `MetricType`: commonly `FLOAT` for one score or `DICT` for grouped outputs
 - whether the metric requires reference audio or reference text
+- whether it requires explicitly ordered multi-source inputs
 - whether it is GPU compatible
 - whether it is installed automatically by the base package
 - dependency import names

--- a/docs/supported_metrics.md
+++ b/docs/supported_metrics.md
@@ -97,6 +97,17 @@ We include x mark if the metric is auto-installed in versa.
 | 27 | x | Chroma-related Alignment | chroma_alignment | chroma_{stft,cqt,cens}_{cosine, euclidean}_dtw{"", _log, _raw} | - | - |
 | 28 | x | Deep Perceptual Audio Metric (DPAM) | dpam | dpam_distance | [PerceptualAudio_Pytorch](https://github.com/adrienchaton/PerceptualAudio_pytorch)  | [paper](https://arxiv.org/abs/2001.04460) |
 | 29 | x | Contrastive learning-based Deep Perceptual Audio Metric (CDPAM) | cdpam | cdpam_distance | [PerceptualAudio](https://github.com/pranaymanocha/PerceptualAudio/cdpam) | [paper](https://arxiv.org/abs/2102.05109) |
+| 30 |  | MAPSS Perceptual Separation and Perceptual Match | mapss | mapss_{ps,pm}_{source}; frame-level tables in the MAPSS result directory | [MAPSS](https://github.com/Amir-Ivry/MAPSS-measures) | [paper](https://arxiv.org/abs/2509.09212) |
+
+MAPSS uses a dedicated ordered multi-source input path because each estimate
+must remain paired with its corresponding reference and at least two pairs are
+required. Install the pinned optional backend with `tools/install_mapss.sh`,
+then pass one source-specific SCP per position through `--pred_sources` and
+`--gt_sources`; see `egs/separate_metrics/mapss.yaml`. MAPSS 1.1.2 supports
+Python 3.10--3.12 and requires `transformers<4.53`, so it is intentionally not
+part of the VERSA base installation. Its first use downloads the selected
+pretrained backbone. VERSA retains the frame-level tables because the diagnostic
+PS mean is not the paper's formal utterance-level aggregation.
 
 
 ### Non-match Metrics

--- a/egs/separate_metrics/mapss.yaml
+++ b/egs/separate_metrics/mapss.yaml
@@ -1,0 +1,14 @@
+# MAPSS requires ordered estimates and references for at least two sources.
+# Install its optional backend with: PYTHON=python tools/install_mapss.sh
+- name: mapss
+  source_names:
+    - source_1
+    - source_2
+  model: wav2vec2
+  layer: 2
+  alpha: 1.0
+  add_ci: true
+  seed: 42
+  length_policy: error
+  # Frame-level PS, PM, and confidence tables are retained below this directory.
+  cache_dir: versa_cache/mapss

--- a/test/test_metrics/test_mapss.py
+++ b/test/test_metrics/test_mapss.py
@@ -91,7 +91,7 @@ def test_mapss_metric_validates_source_pairs(
     monkeypatch, predictions, references, message
 ):
     monkeypatch.setattr(mapss, "mapss_compute", lambda **kwargs: FakeResult())
-    metric = mapss.MapssMetric({"save_frame_scores": False})
+    metric = mapss.MapssMetric()
 
     with pytest.raises(ValueError, match=message):
         metric.compute(predictions, references)
@@ -100,7 +100,7 @@ def test_mapss_metric_validates_source_pairs(
 def test_mapss_setup_reports_missing_optional_dependency(monkeypatch):
     monkeypatch.setattr(mapss, "mapss_compute", None)
 
-    with pytest.raises(ImportError, match="tools/install_mapss.sh"):
+    with pytest.raises(ImportError, match=r"tools/install_mapss\.sh"):
         mapss.MapssMetric()
 
 

--- a/test/test_metrics/test_mapss.py
+++ b/test/test_metrics/test_mapss.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from versa.definition import MetricCategory, MetricRegistry, MetricType
+from versa.metric_discovery import create_metric_discovery_registry, describe_metric
+from versa.utterance_metrics import mapss
+
+
+class FakeSummary:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def to_dict(self, orient):
+        assert orient == "index"
+        return self.rows
+
+
+class FakeResult:
+    def __init__(self):
+        self.summary = FakeSummary(
+            {
+                "Vocals": {"ps": 0.75, "pm": 0.8, "ps_frames": 10, "pm_frames": 9},
+                "Drums": {"ps": 0.5, "pm": 0.6, "ps_frames": 8, "pm_frames": 7},
+            }
+        )
+        self.saved = None
+
+    def save(self, directory, plot):
+        self.saved = (directory, plot)
+
+
+def test_mapss_metric_forwards_ordered_sources_and_retains_frames(
+    monkeypatch, tmp_path
+):
+    call = SimpleNamespace(kwargs=None)
+    result = FakeResult()
+
+    def fake_mapss(**kwargs):
+        call.kwargs = kwargs
+        return result
+
+    monkeypatch.setattr(mapss, "mapss_compute", fake_mapss)
+    metric = mapss.MapssMetric(
+        {
+            "source_names": ["Vocals", "Drums"],
+            "cache_dir": tmp_path,
+            "model": "raw",
+            "add_ci": False,
+            "use_gpu": False,
+        }
+    )
+    predictions = [np.ones(8000), np.ones(8000) * 2]
+    references = [np.ones(8000) * 3, np.ones(8000) * 4]
+
+    scores = metric.compute(
+        predictions,
+        references,
+        metadata={"key": "mixture/one", "sample_rate": 16000},
+    )
+
+    assert call.kwargs["output"] is predictions
+    assert call.kwargs["reference"] is references
+    assert call.kwargs["source_names"] == ["Vocals", "Drums"]
+    assert call.kwargs["model"] == "raw"
+    assert call.kwargs["max_gpus"] == 0
+    assert scores == {
+        "mapss_ps_vocals": 0.75,
+        "mapss_pm_vocals": 0.8,
+        "mapss_ps_drums": 0.5,
+        "mapss_pm_drums": 0.6,
+        "mapss_result_dir": str(tmp_path / "results" / "mixture_one-207dc6d4"),
+    }
+    assert result.saved == (tmp_path / "results" / "mixture_one-207dc6d4", False)
+
+
+@pytest.mark.parametrize(
+    ("predictions", "references", "message"),
+    [
+        ([np.ones(10)], [np.ones(10)], "at least two ordered predicted"),
+        ([np.ones(10), np.ones(10)], [np.ones(10)], "at least two ordered reference"),
+        (
+            [np.ones(10), np.ones(10), np.ones(10)],
+            [np.ones(10), np.ones(10)],
+            "same number",
+        ),
+    ],
+)
+def test_mapss_metric_validates_source_pairs(
+    monkeypatch, predictions, references, message
+):
+    monkeypatch.setattr(mapss, "mapss_compute", lambda **kwargs: FakeResult())
+    metric = mapss.MapssMetric({"save_frame_scores": False})
+
+    with pytest.raises(ValueError, match=message):
+        metric.compute(predictions, references)
+
+
+def test_mapss_setup_reports_missing_optional_dependency(monkeypatch):
+    monkeypatch.setattr(mapss, "mapss_compute", None)
+
+    with pytest.raises(ImportError, match="tools/install_mapss.sh"):
+        mapss.MapssMetric()
+
+
+def test_mapss_registration_metadata():
+    registry = MetricRegistry()
+
+    mapss.register_mapss_metric(registry)
+    metadata = registry.get_metadata("MAPSS")
+
+    assert metadata.name == "mapss"
+    assert metadata.category == MetricCategory.DEPENDENT
+    assert metadata.metric_type == MetricType.DICT
+    assert metadata.requires_reference
+    assert metadata.requires_multiple_sources
+    assert metadata.gpu_compatible
+    assert not metadata.auto_install
+    assert metadata.dependencies == ["mapss"]
+    assert registry.get_metric("mapss_measures") is mapss.MapssMetric
+
+
+def test_mapss_is_discoverable_without_optional_backend():
+    registry = create_metric_discovery_registry()
+
+    metadata = registry.get_metadata("mapss")
+    description = describe_metric(registry, "mapss")
+
+    assert metadata.requires_multiple_sources
+    assert metadata.dependencies == ["mapss"]
+    assert "requires_multiple_sources: true" in description
+
+
+def test_mapss_rejects_colliding_normalized_source_names():
+    summary = FakeSummary(
+        {
+            "lead vocal": {"ps": 1, "pm": 1, "ps_frames": 1, "pm_frames": 1},
+            "lead_vocal": {"ps": 1, "pm": 1, "ps_frames": 1, "pm_frames": 1},
+        }
+    )
+
+    with pytest.raises(ValueError, match="remain unique"):
+        mapss._summary_scores(summary)

--- a/test/test_pipeline/test_mapss_pipeline.py
+++ b/test/test_pipeline/test_mapss_pipeline.py
@@ -1,8 +1,9 @@
 import json
+from dataclasses import replace
 
 import pytest
 
-from versa.bin.scorer import get_parser
+from versa.bin.scorer import _text_required_multi_source_metrics, get_parser
 from versa.definition import (
     BaseMetric,
     MetricCategory,
@@ -60,6 +61,20 @@ def test_multi_source_parser_accepts_ordered_scp_lists():
 
     assert args.pred_sources == ["pred-1.scp", "pred-2.scp"]
     assert args.gt_sources == ["ref-1.scp", "ref-2.scp"]
+
+
+def test_multi_source_rejects_only_metrics_that_require_text():
+    metadata = OrderedSourceMetric().get_metadata()
+    score_config = [{"name": "ordered_source"}]
+
+    assert (
+        _text_required_multi_source_metrics(score_config, {"ordered_source": metadata})
+        == []
+    )
+    assert _text_required_multi_source_metrics(
+        score_config,
+        {"ordered_source": replace(metadata, requires_text=True)},
+    ) == ["ordered_source"]
 
 
 def test_multi_source_pipeline_preserves_order_and_writes_jsonl(tmp_path):

--- a/test/test_pipeline/test_mapss_pipeline.py
+++ b/test/test_pipeline/test_mapss_pipeline.py
@@ -1,9 +1,16 @@
 import json
+import sys
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 
-from versa.bin.scorer import _text_required_multi_source_metrics, get_parser
+from versa import config_validation, scorer_shared
+from versa.bin.scorer import (
+    _text_required_multi_source_metrics,
+    get_parser,
+    main as scorer_main,
+)
 from versa.definition import (
     BaseMetric,
     MetricCategory,
@@ -66,15 +73,64 @@ def test_multi_source_parser_accepts_ordered_scp_lists():
 def test_multi_source_rejects_only_metrics_that_require_text():
     metadata = OrderedSourceMetric().get_metadata()
     score_config = [{"name": "ordered_source"}]
+    registry = MetricRegistry()
+    registry.register(OrderedSourceMetric, metadata)
 
-    assert (
-        _text_required_multi_source_metrics(score_config, {"ordered_source": metadata})
-        == []
+    assert _text_required_multi_source_metrics(score_config, registry) == []
+
+    text_registry = MetricRegistry()
+    text_registry.register(OrderedSourceMetric, replace(metadata, requires_text=True))
+    assert _text_required_multi_source_metrics(score_config, text_registry) == [
+        "ordered_source"
+    ]
+
+
+def test_multi_source_cli_rejects_text_metric_before_generic_validation(
+    monkeypatch, tmp_path, capsys
+):
+    registry = MetricRegistry()
+    registry.register(
+        OrderedSourceMetric,
+        replace(OrderedSourceMetric().get_metadata(), requires_text=True),
     )
-    assert _text_required_multi_source_metrics(
-        score_config,
-        {"ordered_source": replace(metadata, requires_text=True)},
-    ) == ["ordered_source"]
+    monkeypatch.setattr(
+        scorer_shared,
+        "VersaScorer",
+        lambda: SimpleNamespace(registry=registry),
+    )
+
+    def unexpected_validation(*args, **kwargs):
+        pytest.fail("generic validation ran before multi-source text validation")
+
+    monkeypatch.setattr(
+        config_validation, "validate_score_config", unexpected_validation
+    )
+    config_path = tmp_path / "text_metric.yaml"
+    config_path.write_text("- name: ordered_source\n", encoding="utf-8")
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "versa-scorer",
+            "--score_config",
+            str(config_path),
+            "--pred_sources",
+            "pred-1.scp",
+            "pred-2.scp",
+            "--gt_sources",
+            "ref-1.scp",
+            "ref-2.scp",
+        ],
+    )
+
+    with pytest.raises(SystemExit) as error:
+        scorer_main()
+
+    assert error.value.code == 2
+    assert (
+        "does not yet support metrics requiring reference text"
+        in capsys.readouterr().err
+    )
 
 
 def test_multi_source_pipeline_preserves_order_and_writes_jsonl(tmp_path):

--- a/test/test_pipeline/test_mapss_pipeline.py
+++ b/test/test_pipeline/test_mapss_pipeline.py
@@ -1,0 +1,111 @@
+import json
+
+import pytest
+
+from versa.bin.scorer import get_parser
+from versa.definition import (
+    BaseMetric,
+    MetricCategory,
+    MetricMetadata,
+    MetricRegistry,
+    MetricType,
+)
+from versa.scorer_shared import VersaScorer, find_files
+
+
+class OrderedSourceMetric(BaseMetric):
+    calls = []
+
+    def _setup(self):
+        pass
+
+    def compute(self, predictions, references=None, metadata=None):
+        self.calls.append((predictions, references, metadata))
+        return {"ordered_source_score": float(len(predictions))}
+
+    def get_metadata(self):
+        return MetricMetadata(
+            name="ordered_source",
+            category=MetricCategory.DEPENDENT,
+            metric_type=MetricType.DICT,
+            requires_reference=True,
+            requires_text=False,
+            gpu_compatible=False,
+            auto_install=False,
+            dependencies=[],
+            description="Dependency-light ordered source test metric.",
+            requires_multiple_sources=True,
+        )
+
+
+def _source_mappings():
+    sample_files = list(find_files("test/test_samples/test2").values())
+    sample_file = sample_files[0]
+    keys = ["mixture-a", "mixture-b"]
+    mapping = {key: sample_file for key in keys}
+    return [dict(mapping), dict(mapping)], [dict(mapping), dict(mapping)]
+
+
+def test_multi_source_parser_accepts_ordered_scp_lists():
+    args = get_parser().parse_args(
+        [
+            "--pred_sources",
+            "pred-1.scp",
+            "pred-2.scp",
+            "--gt_sources",
+            "ref-1.scp",
+            "ref-2.scp",
+        ]
+    )
+
+    assert args.pred_sources == ["pred-1.scp", "pred-2.scp"]
+    assert args.gt_sources == ["ref-1.scp", "ref-2.scp"]
+
+
+def test_multi_source_pipeline_preserves_order_and_writes_jsonl(tmp_path):
+    registry = MetricRegistry()
+    metadata = OrderedSourceMetric().get_metadata()
+    registry.register(OrderedSourceMetric, metadata)
+    scorer = VersaScorer(registry)
+    suite = scorer.load_metrics([{"name": "ordered_source"}], use_gt=True)
+    predictions, references = _source_mappings()
+    output_file = tmp_path / "mapss.jsonl"
+
+    OrderedSourceMetric.calls = []
+    scores = scorer.score_multi_source_utterances(
+        predictions,
+        suite,
+        references,
+        output_file=str(output_file),
+        io="soundfile",
+    )
+
+    assert scores == [
+        {"key": "mixture-a", "ordered_source_score": 2.0},
+        {"key": "mixture-b", "ordered_source_score": 2.0},
+    ]
+    assert len(OrderedSourceMetric.calls) == 2
+    assert all(
+        len(call[0]) == 2 and len(call[1]) == 2 for call in OrderedSourceMetric.calls
+    )
+    assert all(call[2]["sample_rate"] == 16000 for call in OrderedSourceMetric.calls)
+    assert [
+        json.loads(line)
+        for line in output_file.read_text(encoding="utf-8").splitlines()
+    ] == scores
+
+
+def test_multi_source_pipeline_rejects_key_mismatch():
+    registry = MetricRegistry()
+    metadata = OrderedSourceMetric().get_metadata()
+    registry.register(OrderedSourceMetric, metadata)
+    scorer = VersaScorer(registry)
+    suite = scorer.load_metrics([{"name": "ordered_source"}], use_gt=True)
+
+    with pytest.raises(ValueError, match="missing keys"):
+        scorer.score_multi_source_utterances(
+            [{"a": "one.wav"}, {"a": "two.wav"}],
+            suite,
+            [{"a": "one.wav"}, {}],
+            io="soundfile",
+        )

--- a/tools/install_mapss.sh
+++ b/tools/install_mapss.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+PYTHON_BIN="${PYTHON:-python}"
+
+"$PYTHON_BIN" -c '
+import sys
+if not ((3, 10) <= sys.version_info[:2] < (3, 13)):
+    raise SystemExit(
+        "MAPSS 1.1.2 requires Python 3.10-3.12; "
+        f"this interpreter is Python {sys.version_info.major}.{sys.version_info.minor}."
+    )
+'
+
+"$PYTHON_BIN" -c '
+from importlib.metadata import PackageNotFoundError, version
+try:
+    installed = version("transformers")
+except PackageNotFoundError:
+    pass
+else:
+    major_minor = tuple(int(part) for part in installed.split(".")[:2])
+    if major_minor >= (4, 53):
+        print(
+            "WARNING: MAPSS 1.1.2 requires transformers<4.53 and pip may "
+            f"replace the installed transformers {installed}. Consider a "
+            "dedicated virtual environment."
+        )
+'
+
+"$PYTHON_BIN" -m pip install "mapss-measures==1.1.2"
+"$PYTHON_BIN" -m pip check
+
+echo "MAPSS 1.1.2 is ready. The default backbone downloads on first use."

--- a/tools/install_mapss.sh
+++ b/tools/install_mapss.sh
@@ -22,10 +22,10 @@ except PackageNotFoundError:
 else:
     major_minor = tuple(int(part) for part in installed.split(".")[:2])
     if major_minor >= (4, 53):
-        print(
-            "WARNING: MAPSS 1.1.2 requires transformers<4.53 and pip may "
-            f"replace the installed transformers {installed}. Consider a "
-            "dedicated virtual environment."
+        raise SystemExit(
+            "MAPSS 1.1.2 requires transformers<4.53, but this environment has "
+            f"transformers {installed}. Refusing to modify the environment; "
+            "install MAPSS in a dedicated compatible virtual environment."
         )
 '
 

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -37,6 +37,25 @@ def get_parser() -> argparse.Namespace:
         help="Wav.scp for ground truth waveforms.",
     )
     parser.add_argument(
+        "--pred_sources",
+        "--pred-sources",
+        nargs="+",
+        default=None,
+        metavar="SCP",
+        help=(
+            "Ordered source-specific wav.scp files for multi-source metrics. "
+            "Use with --gt_sources; source position defines the assignment."
+        ),
+    )
+    parser.add_argument(
+        "--gt_sources",
+        "--gt-sources",
+        nargs="+",
+        default=None,
+        metavar="SCP",
+        help="Ordered reference source wav.scp files for multi-source metrics.",
+    )
+    parser.add_argument(
         "--text", type=str, default=None, help="Path of ground truth transcription."
     )
     parser.add_argument(
@@ -258,6 +277,23 @@ def main():
     configure_shared_cache_environment(args.cache_folder)
     score_config = configure_metric_cache_dirs(score_config, args.cache_folder)
 
+    multi_source_mode = args.pred_sources is not None or args.gt_sources is not None
+    if multi_source_mode:
+        if args.pred_sources is None or args.gt_sources is None:
+            parser.error("--pred_sources and --gt_sources must be provided together")
+        if args.pred is not None or args.gt is not None:
+            parser.error(
+                "--pred_sources/--gt_sources cannot be combined with --pred/--gt"
+            )
+        if args.no_match:
+            parser.error("--no_match is not valid for multi-source scoring")
+        if args.num_workers != 1:
+            parser.error("multi-source scoring currently requires --num_workers 1")
+        if args.scoring_mode != "utterance":
+            parser.error("multi-source scoring currently uses --scoring_mode utterance")
+    elif args.pred is None:
+        parser.error("--pred is required unless --pred_sources is used")
+
     # Validate before any scoring or model setup begins.
     scorer = VersaScorer()
     try:
@@ -266,12 +302,79 @@ def main():
         validate_score_config(
             score_config,
             registry=scorer.registry,
-            use_gt=(args.gt is not None and args.gt != "None" and not args.no_match),
+            use_gt=(
+                args.gt_sources is not None
+                if multi_source_mode
+                else args.gt is not None and args.gt != "None" and not args.no_match
+            ),
             use_gt_text=(args.text is not None),
             use_gpu=args.use_gpu,
         )
     except ValueError as e:
         parser.error(str(e))
+
+    score_metadata = {
+        config["name"]: scorer.registry.get_metadata(config["name"])
+        for config in score_config
+    }
+    multi_source_score_config = [
+        config
+        for config in score_config
+        if score_metadata[config["name"]]
+        and score_metadata[config["name"]].requires_multiple_sources
+    ]
+
+    if multi_source_mode:
+        if len(multi_source_score_config) != len(score_config):
+            parser.error(
+                "--pred_sources/--gt_sources can only be used with metrics that "
+                "declare multi-source input"
+            )
+        if len(args.pred_sources) < 2 or len(args.gt_sources) < 2:
+            parser.error("multi-source scoring requires at least two source SCPs")
+        if len(args.pred_sources) != len(args.gt_sources):
+            parser.error(
+                "--pred_sources and --gt_sources must contain the same number of SCPs"
+            )
+
+        gen_source_files = [
+            audio_loader_setup(path, args.io) for path in args.pred_sources
+        ]
+        gt_source_files = [
+            audio_loader_setup(path, args.io) for path in args.gt_sources
+        ]
+        multi_source_metrics = scorer.load_metrics(
+            multi_source_score_config,
+            use_gt=True,
+            use_gt_text=False,
+            use_gpu=args.use_gpu,
+        )
+        if not multi_source_metrics.metrics:
+            raise ValueError("No multi-source scoring function is available")
+        score_info = scorer.score_multi_source_utterances(
+            gen_source_files,
+            multi_source_metrics,
+            gt_source_files,
+            output_file=args.output_file,
+            io=args.io,
+            resume=args.resume,
+        )
+        logging.info("Summary: %s", compute_summary(score_info))
+        if args.report:
+            _write_report(
+                score_info,
+                args.report,
+                report_format=args.report_format,
+                group_by=args.report_group_by,
+                outlier_limit=args.report_outlier_limit,
+                registry=scorer.registry,
+            )
+        return
+
+    if multi_source_score_config:
+        parser.error(
+            "multi-source metrics require ordered --pred_sources and --gt_sources"
+        )
 
     gen_files = audio_loader_setup(args.pred, args.io)
 
@@ -305,10 +408,6 @@ def main():
     logging.info("The number of utterances = %d" % len(gen_files))
 
     # Initialize VersaScorer
-    score_metadata = {
-        config["name"]: scorer.registry.get_metadata(config["name"])
-        for config in score_config
-    }
     corpus_score_config = [
         config
         for config in score_config

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -205,6 +205,17 @@ def get_parser() -> argparse.Namespace:
     return parser
 
 
+def _text_required_multi_source_metrics(score_config, score_metadata):
+    """Return configured multi-source metrics needing unsupported text input."""
+    return [
+        config["name"]
+        for config in score_config
+        if score_metadata[config["name"]]
+        and score_metadata[config["name"]].requires_multiple_sources
+        and score_metadata[config["name"]].requires_text
+    ]
+
+
 def main():
     parser = get_parser()
     args = parser.parse_args()
@@ -325,6 +336,14 @@ def main():
     ]
 
     if multi_source_mode:
+        text_required_metrics = _text_required_multi_source_metrics(
+            score_config, score_metadata
+        )
+        if text_required_metrics:
+            parser.error(
+                "multi-source scoring does not yet support metrics requiring "
+                "reference text: " + ", ".join(text_required_metrics)
+            )
         if len(multi_source_score_config) != len(score_config):
             parser.error(
                 "--pred_sources/--gt_sources can only be used with metrics that "

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -361,6 +361,8 @@ def main():
         )
         logging.info("Summary: %s", compute_summary(score_info))
         if args.report:
+            if not score_info:
+                raise ValueError("--report requires at least one utterance-level score")
             _write_report(
                 score_info,
                 args.report,

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -205,15 +205,20 @@ def get_parser() -> argparse.Namespace:
     return parser
 
 
-def _text_required_multi_source_metrics(score_config, score_metadata):
+def _text_required_multi_source_metrics(score_config, registry):
     """Return configured multi-source metrics needing unsupported text input."""
-    return [
-        config["name"]
-        for config in score_config
-        if score_metadata[config["name"]]
-        and score_metadata[config["name"]].requires_multiple_sources
-        and score_metadata[config["name"]].requires_text
-    ]
+    if not isinstance(score_config, list):
+        return []
+
+    unsupported = []
+    for config in score_config:
+        if not isinstance(config, dict):
+            continue
+        metric_name = config.get("name")
+        metadata = registry.get_metadata(metric_name)
+        if metadata and metadata.requires_multiple_sources and metadata.requires_text:
+            unsupported.append(metric_name)
+    return unsupported
 
 
 def main():
@@ -307,6 +312,16 @@ def main():
 
     # Validate before any scoring or model setup begins.
     scorer = VersaScorer()
+    if multi_source_mode:
+        text_required_metrics = _text_required_multi_source_metrics(
+            score_config, scorer.registry
+        )
+        if text_required_metrics:
+            parser.error(
+                "multi-source scoring does not yet support metrics requiring "
+                "reference text: " + ", ".join(text_required_metrics)
+            )
+
     try:
         from versa.config_validation import validate_score_config
 
@@ -336,14 +351,6 @@ def main():
     ]
 
     if multi_source_mode:
-        text_required_metrics = _text_required_multi_source_metrics(
-            score_config, score_metadata
-        )
-        if text_required_metrics:
-            parser.error(
-                "multi-source scoring does not yet support metrics requiring "
-                "reference text: " + ", ".join(text_required_metrics)
-            )
         if len(multi_source_score_config) != len(score_config):
             parser.error(
                 "--pred_sources/--gt_sources can only be used with metrics that "

--- a/versa/definition.py
+++ b/versa/definition.py
@@ -43,6 +43,7 @@ class MetricMetadata:
     description: str
     paper_reference: Optional[str] = None
     implementation_source: Optional[str] = None
+    requires_multiple_sources: bool = False
 
 
 class MetricRegistry:

--- a/versa/metric_discovery.py
+++ b/versa/metric_discovery.py
@@ -200,6 +200,7 @@ def describe_metric(registry: MetricRegistry, metric_name: str) -> str:
         f"category: {metadata.category.value}",
         f"type: {metadata.metric_type.value}",
         f"requires_reference: {str(metadata.requires_reference).lower()}",
+        "requires_multiple_sources: " + str(metadata.requires_multiple_sources).lower(),
         f"requires_text: {str(metadata.requires_text).lower()}",
         f"gpu_compatible: {str(metadata.gpu_compatible).lower()}",
         f"auto_install: {str(metadata.auto_install).lower()}",
@@ -550,6 +551,7 @@ def _metadata_from_call(node: ast.AST) -> Optional[Any]:
         "description",
         "paper_reference",
         "implementation_source",
+        "requires_multiple_sources",
     ]
     for field, value in zip(positional_fields, node.args):
         values[field] = _literal_metric_value(value)

--- a/versa/metric_registry.py
+++ b/versa/metric_registry.py
@@ -221,6 +221,11 @@ METRIC_MODULES = (
         "Please install SongEval dependencies following tools/install_songeval.sh",
     ),
     MetricModuleSpec(
+        "versa.utterance_metrics.mapss",
+        ("MapssMetric", "register_mapss_metric"),
+        "Please install MAPSS following tools/install_mapss.sh",
+    ),
+    MetricModuleSpec(
         "versa.utterance_metrics.vad",
         ("VadMetric", "register_vad_metric"),
     ),

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -314,6 +314,41 @@ def _write_jsonl_score(file_handle, utt_score: Dict[str, Any]) -> None:
     file_handle.flush()
 
 
+def _validate_multi_source_file_sets(gen_source_files, gt_source_files):
+    """Validate ordered source mappings and return stable mixture key order."""
+    if len(gen_source_files) < 2 or len(gt_source_files) < 2:
+        raise ValueError(
+            "Multi-source scoring requires at least two generated and two "
+            "reference source mappings"
+        )
+    if len(gen_source_files) != len(gt_source_files):
+        raise ValueError(
+            "Generated and reference source mapping counts must match; received "
+            f"{len(gen_source_files)} and {len(gt_source_files)}"
+        )
+
+    keys = list(gen_source_files[0])
+    if not keys:
+        raise ValueError("Multi-source scoring received no mixture keys")
+    expected = set(keys)
+    mappings = [
+        *(f"generated source {index}" for index in range(len(gen_source_files))),
+        *(f"reference source {index}" for index in range(len(gt_source_files))),
+    ]
+    for label, source_files in zip(mappings, [*gen_source_files, *gt_source_files]):
+        actual = set(source_files)
+        if actual != expected:
+            missing = sorted(expected - actual)
+            extra = sorted(actual - expected)
+            details = []
+            if missing:
+                details.append("missing keys: " + ", ".join(missing[:5]))
+            if extra:
+                details.append("unexpected keys: " + ", ".join(extra[:5]))
+            raise ValueError(f"{label} does not match source 0 ({'; '.join(details)})")
+    return keys
+
+
 def _release_metric_resources() -> None:
     """Best-effort cleanup after unloading model-backed metrics."""
     gc.collect()
@@ -585,6 +620,109 @@ class VersaScorer:
 
         self.logger.info(f"Scoring completed. Results saved to {output_file}")
         return score_info
+
+    def score_multi_source_utterances(
+        self,
+        gen_source_files: List[Dict[str, Any]],
+        metric_suite: MetricSuite,
+        gt_source_files: List[Dict[str, Any]],
+        output_file: Optional[str] = None,
+        io: str = "soundfile",
+        resume: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Score explicitly ordered source pairs for each mixture.
+
+        Each item in ``gen_source_files`` and ``gt_source_files`` is one
+        source-specific SCP mapping. List order defines the source assignment.
+        This path is intentionally separate from single-utterance scoring so a
+        metric such as MAPSS cannot silently infer or permute source pairs.
+        """
+
+        keys = _validate_multi_source_file_sets(gen_source_files, gt_source_files)
+        if not metric_suite.metrics:
+            raise ValueError("No multi-source scoring function is available")
+        if any(
+            not metric.get_metadata().requires_multiple_sources
+            for metric in metric_suite.metrics.values()
+        ):
+            raise ValueError(
+                "Multi-source scoring only accepts metrics declared with "
+                "requires_multiple_sources=True"
+            )
+
+        existing_scores = _load_existing_jsonl_scores(output_file) if resume else {}
+        completed_keys = set(existing_scores).intersection(keys)
+        score_by_key = {
+            key: existing_scores[key] for key in keys if key in existing_scores
+        }
+
+        file_handle = None
+        if output_file:
+            mode = "a" if resume else "w"
+            if resume:
+                _ensure_append_starts_on_new_line(output_file)
+            file_handle = open(output_file, mode, encoding="utf-8")
+
+        try:
+            for key in tqdm(keys):
+                if key in completed_keys:
+                    continue
+
+                predictions = []
+                references = []
+                valid = True
+                for source_index, source_files in enumerate(gen_source_files):
+                    sr, waveform = load_audio(source_files[key], io)
+                    waveform = wav_normalize(waveform)
+                    if not self._validate_audio(
+                        waveform,
+                        sr,
+                        key,
+                        f"generated source {source_index}",
+                        metric_suite.metrics.keys(),
+                    ):
+                        valid = False
+                        break
+                    predictions.append(resample_audio(waveform, sr, 16000))
+                if not valid:
+                    continue
+
+                for source_index, source_files in enumerate(gt_source_files):
+                    sr, waveform = load_audio(source_files[key], io)
+                    waveform = wav_normalize(waveform)
+                    if not self._validate_audio(
+                        waveform,
+                        sr,
+                        key,
+                        f"reference source {source_index}",
+                        metric_suite.metrics.keys(),
+                    ):
+                        valid = False
+                        break
+                    references.append(resample_audio(waveform, sr, 16000))
+                if not valid:
+                    continue
+
+                metadata = {
+                    "key": key,
+                    "sample_rate": 16000,
+                }
+                utt_score = {"key": key}
+                scores = metric_suite.compute_all(predictions, references, metadata)
+                for metric_name, metric_results in scores.items():
+                    if isinstance(metric_results, dict):
+                        utt_score.update(metric_results)
+                    else:
+                        utt_score[metric_name] = metric_results
+
+                score_by_key[key] = utt_score
+                if file_handle:
+                    _write_jsonl_score(file_handle, utt_score)
+        finally:
+            if file_handle:
+                file_handle.close()
+
+        return [score_by_key[key] for key in keys if key in score_by_key]
 
     def _score_utterances_parallel(
         self,

--- a/versa/utterance_metrics/mapss.py
+++ b/versa/utterance_metrics/mapss.py
@@ -70,17 +70,9 @@ class MapssMetric(BaseMetric):
         self.length_policy = self.config.get("length_policy", "error")
         self.verbose = self.config.get("verbose", False)
         self.source_names = self.config.get("source_names")
-        self.save_frame_scores = self.config.get("save_frame_scores", True)
         cache_dir = Path(self.config.get("cache_dir", "versa_cache/mapss"))
-        self.results_dir = Path(self.config.get("results_dir", cache_dir / "results"))
-
-        configured_max_gpus = self.config.get("max_gpus")
-        if configured_max_gpus is not None:
-            self.max_gpus = configured_max_gpus
-        elif self.config.get("use_gpu", False):
-            self.max_gpus = 1
-        else:
-            self.max_gpus = 0
+        self.results_dir = cache_dir / "results"
+        self.max_gpus = int(self.config.get("use_gpu", False))
 
     def compute(self, predictions, references=None, metadata=None):
         if not isinstance(predictions, (list, tuple)) or len(predictions) < 2:
@@ -114,12 +106,11 @@ class MapssMetric(BaseMetric):
         )
 
         scores = _summary_scores(result.summary)
-        if self.save_frame_scores:
-            result_dir = self.results_dir / _result_directory_name(
-                metadata.get("key", "mixture")
-            )
-            result.save(result_dir, plot=False)
-            scores["mapss_result_dir"] = str(result_dir)
+        result_dir = self.results_dir / _result_directory_name(
+            metadata.get("key", "mixture")
+        )
+        result.save(result_dir, plot=False)
+        scores["mapss_result_dir"] = str(result_dir)
         return scores
 
     def get_metadata(self):

--- a/versa/utterance_metrics/mapss.py
+++ b/versa/utterance_metrics/mapss.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Jiatong Shi
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Optional MAPSS integration for ordered source-separation outputs."""
+
+import hashlib
+import re
+from pathlib import Path
+
+from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
+
+try:
+    from mapss import mapss as mapss_compute
+except ImportError:
+    mapss_compute = None
+
+
+def _require_mapss():
+    if mapss_compute is None:
+        raise ImportError(
+            "MAPSS is an optional dependency. Install the pinned backend with "
+            "`tools/install_mapss.sh`. MAPSS 1.1.2 supports Python 3.10-3.12."
+        )
+
+
+def _safe_path_component(value):
+    component = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value)).strip("._")
+    return component or "mixture"
+
+
+def _result_directory_name(value):
+    text = str(value)
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
+    return f"{_safe_path_component(text)}-{digest}"
+
+
+def _summary_scores(summary):
+    """Convert MAPSS's diagnostic summary table to stable VERSA keys."""
+    rows = summary.to_dict(orient="index")
+    normalized_names = {}
+    for source_name in rows:
+        normalized = _safe_path_component(source_name).lower()
+        if normalized in normalized_names:
+            raise ValueError(
+                "MAPSS source names must remain unique after normalization; "
+                f"{source_name!r} conflicts with {normalized_names[normalized]!r}"
+            )
+        normalized_names[normalized] = source_name
+
+    scores = {}
+    for normalized, source_name in normalized_names.items():
+        row = rows[source_name]
+        scores[f"mapss_ps_{normalized}"] = float(row["ps"])
+        scores[f"mapss_pm_{normalized}"] = float(row["pm"])
+    return scores
+
+
+class MapssMetric(BaseMetric):
+    """Manifold-based perceptual assessment for ordered separated sources."""
+
+    def _setup(self):
+        _require_mapss()
+        self.model = self.config.get("model", "wav2vec2")
+        self.layer = self.config.get("layer")
+        self.alpha = self.config.get("alpha", 1.0)
+        self.add_ci = self.config.get("add_ci", True)
+        self.seed = self.config.get("seed", 42)
+        self.length_policy = self.config.get("length_policy", "error")
+        self.verbose = self.config.get("verbose", False)
+        self.source_names = self.config.get("source_names")
+        self.save_frame_scores = self.config.get("save_frame_scores", True)
+        cache_dir = Path(self.config.get("cache_dir", "versa_cache/mapss"))
+        self.results_dir = Path(self.config.get("results_dir", cache_dir / "results"))
+
+        configured_max_gpus = self.config.get("max_gpus")
+        if configured_max_gpus is not None:
+            self.max_gpus = configured_max_gpus
+        elif self.config.get("use_gpu", False):
+            self.max_gpus = 1
+        else:
+            self.max_gpus = 0
+
+    def compute(self, predictions, references=None, metadata=None):
+        if not isinstance(predictions, (list, tuple)) or len(predictions) < 2:
+            raise ValueError(
+                "MAPSS requires at least two ordered predicted source waveforms"
+            )
+        if not isinstance(references, (list, tuple)) or len(references) < 2:
+            raise ValueError(
+                "MAPSS requires at least two ordered reference source waveforms"
+            )
+        if len(predictions) != len(references):
+            raise ValueError(
+                "MAPSS requires the same number of ordered predicted and reference "
+                "sources"
+            )
+
+        metadata = metadata or {}
+        result = mapss_compute(
+            reference=references,
+            output=predictions,
+            sample_rate=metadata.get("sample_rate", 16000),
+            source_names=self.source_names,
+            model=self.model,
+            layer=self.layer,
+            alpha=self.alpha,
+            add_ci=self.add_ci,
+            seed=self.seed,
+            max_gpus=self.max_gpus,
+            length_policy=self.length_policy,
+            verbose=self.verbose,
+        )
+
+        scores = _summary_scores(result.summary)
+        if self.save_frame_scores:
+            result_dir = self.results_dir / _result_directory_name(
+                metadata.get("key", "mixture")
+            )
+            result.save(result_dir, plot=False)
+            scores["mapss_result_dir"] = str(result_dir)
+        return scores
+
+    def get_metadata(self):
+        return _mapss_metadata()
+
+
+def _mapss_metadata():
+    return MetricMetadata(
+        name="mapss",
+        category=MetricCategory.DEPENDENT,
+        metric_type=MetricType.DICT,
+        requires_reference=True,
+        requires_text=False,
+        gpu_compatible=True,
+        auto_install=False,
+        dependencies=["mapss"],
+        description=(
+            "MAPSS perceptual separation and match measures for ordered source pairs"
+        ),
+        paper_reference="https://arxiv.org/abs/2509.09212",
+        implementation_source="https://github.com/Amir-Ivry/MAPSS-measures",
+        requires_multiple_sources=True,
+    )
+
+
+def register_mapss_metric(registry):
+    registry.register(
+        MapssMetric,
+        _mapss_metadata(),
+        aliases=["MAPSS", "mapss_measures"],
+    )


### PR DESCRIPTION
## Summary

- add MAPSS as an optional, lazy-loaded dependent metric
- add an explicit ordered multi-source scoring path using source-specific SCP files
- retain MAPSS frame-level artifacts while exposing PS/PM convenience summaries in VERSA JSONL output
- add a pinned installer with Python and Transformers compatibility checks
- document installation, source ordering, aggregation caveats, and example usage

## Dependency policy

MAPSS is intentionally not added to VERSA's base or optional dependency groups. `tools/install_mapss.sh` pins `mapss-measures==1.1.2`, checks for Python 3.10-3.12, warns before a possible `transformers>=4.53` downgrade, and runs `pip check` after installation.

## Usage

```bash
PYTHON=python tools/install_mapss.sh
versa-score \
  --score_config egs/separate_metrics/mapss.yaml \
  --pred_sources estimates/source1.scp estimates/source2.scp \
  --gt_sources references/source1.scp references/source2.scp \
  --output_file mapss.jsonl \
  --io soundfile \
  --use_gpu
```

Source position is the assignment: predicted source `i` must estimate reference source `i`. All SCP files must contain identical mixture keys.

## Validation

- `python -m pytest -q test/test_metrics/test_mapss.py test/test_pipeline/test_mapss_pipeline.py test/test_metrics/test_definition.py test/test_pipeline/test_base_metrics_pipeline.py` — 44 passed
- Black check on all changed Python files
- Flake8 critical-error checks
- `bash -n tools/install_mapss.sh`
- `git diff --check`

Real MAPSS model inference was not run in the existing development environment because MAPSS 1.1.2 requires `transformers<4.53`; the current environment uses Transformers 4.57.6. The real-model check should run in a dedicated compatible environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional MAPSS perceptual separation and matching support for ordered multi-source audio.
  * Added multi-source scoring with source-specific prediction and reference inputs, validation, resume support, and per-utterance results.
  * Added configurable MAPSS models, confidence intervals, reproducible settings, and frame-level diagnostic results.
* **Documentation**
  * Added setup, compatibility, usage, output, interpretation, and contributor guidance.
* **Chores**
  * Added an installation script with environment checks and readiness validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->