### PR TITLE
Fix multi-source signal_metric crash; add opt-in permutation-invarian…

### DIFF
--- a/test/test_metrics/test_signal_metric_multisource.py
+++ b/test/test_metrics/test_signal_metric_multisource.py
@@ -172,3 +172,16 @@ def test_permutation_three_source_cyclic_shift():
         assert out[f"sdr_src{i}"] > 20.0
     # and without the flag the same input scores as a failure
     assert signal_metric(est, refs)["si_snr"] < 0.0
+
+
+@pytest.mark.parametrize("compute_permutation", [False, True])
+@pytest.mark.parametrize("n_est, n_ref", [(2, 3), (3, 2), (1, 2), (2, 1)])
+def test_mismatched_source_count_raises_clearly(compute_permutation, n_est, n_ref):
+    """The contract is enforced before either backend sees the arrays, so the
+    error is the same clear ValueError with or without permutation instead
+    of an einsum failure from fast_bss_eval."""
+    rng = np.random.RandomState(0)
+    est = rng.random((n_est, 8000))
+    ref = rng.random((n_ref, 8000))
+    with pytest.raises(ValueError, match=rf"{n_est} estimated and {n_ref} reference"):
+        signal_metric(est, ref, compute_permutation=compute_permutation)

--- a/test/test_metrics/test_signal_metric_multisource.py
+++ b/test/test_metrics/test_signal_metric_multisource.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Zhuoyan Tao
+#  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
+
+"""Tests for multi-source and permutation-invariant signal metrics."""
+
+import numpy as np
+import pytest
+
+from versa.sequence_metrics.signal_metric import (
+    SignalMetric,
+    calculate_ci_sdr,
+    calculate_si_snr,
+    signal_metric,
+)
+
+# ---------------------------------------------------------------------------
+# backward compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_single_source_helpers_still_return_float():
+    """The per-source return is opt-in, so existing callers are unaffected."""
+    rng = np.random.default_rng(0)
+    a = rng.random(16000).astype("float32")
+    b = rng.random(16000).astype("float32")
+    assert isinstance(calculate_si_snr(a, b), float)
+    assert isinstance(calculate_ci_sdr(a, b), float)
+    mean, per_src = calculate_si_snr(a, b, return_per_source=True)
+    assert isinstance(mean, float) and len(per_src) == 1
+
+
+def test_single_source_keys_unchanged():
+    """A single-source call returns exactly the original five keys."""
+    rng = np.random.default_rng(1)
+    a = rng.random(8000).astype("float32")
+    b = rng.random(8000).astype("float32")
+    out = signal_metric(a, b)
+    assert set(out) == {"sdr", "sir", "sar", "si_snr", "ci_sdr"}
+
+
+def test_permutation_off_by_default():
+    """Default behaviour must not change for anyone."""
+    metric = SignalMetric()
+    assert metric.compute_permutation is False
+
+
+# ---------------------------------------------------------------------------
+# multi-source support
+# ---------------------------------------------------------------------------
+
+
+def test_multi_source_does_not_raise():
+    """Two sources used to raise: float() on a multi-element tensor."""
+    rng = np.random.default_rng(2)
+    refs = rng.random((2, 8000)).astype("float32")
+    preds = rng.random((2, 8000)).astype("float32")
+    out = signal_metric(preds, refs)
+    assert "sdr_src0" in out and "sdr_src1" in out
+    assert "si_snr_src0" in out and "ci_sdr_src1" in out
+
+
+def test_permutation_recovers_swapped_sources():
+    """A correct separation emitted in the wrong order is a success, not a
+    failure. Without permutation it scores as though it had failed."""
+    rng = np.random.default_rng(3)
+    s1 = rng.standard_normal(8000).astype("float32")
+    s2 = rng.standard_normal(8000).astype("float32")
+    refs = np.stack([s1, s2])
+    swapped = np.stack([s2, s1])
+
+    without = signal_metric(swapped, refs, compute_permutation=False)
+    with_perm = signal_metric(swapped, refs, compute_permutation=True)
+
+    # the swapped estimate IS the reference set, so resolving the assignment
+    # should improve SDR by a wide margin
+    assert with_perm["sdr"] > without["sdr"] + 20.0
+    assert with_perm["permutation"] in ([1, 0], [1, 0])
+
+
+def test_permutation_noop_when_already_aligned():
+    """Correctly ordered sources must not be made worse by enabling PIT.
+
+    The two paths use different bss_eval backends -- mir_eval when no
+    permutation is requested, fast_bss_eval when one is -- and they solve for
+    the 512-tap distortion filter by different linear algebra. On a pair this
+    close (~40 dB) that estimation is ill-conditioned, so the last digits
+    genuinely differ: 40.2755 against 40.2803 for this seed. The tolerance is
+    therefore 0.05 dB rather than the 1e-6 a single shared backend allowed,
+    still orders of magnitude tighter than any difference a wrong permutation
+    would produce.
+    """
+    rng = np.random.default_rng(4)
+    refs = rng.standard_normal((2, 8000)).astype("float32")
+    preds = refs + 0.01 * rng.standard_normal((2, 8000)).astype("float32")
+    without = signal_metric(preds, refs, compute_permutation=False)
+    with_perm = signal_metric(preds, refs, compute_permutation=True)
+    assert with_perm["sdr"] >= without["sdr"] - 0.05
+    assert with_perm["permutation"] == [0, 1]
+
+
+def test_permutation_ignored_for_single_source():
+    """No permutation exists for one source; the flag must be harmless."""
+    rng = np.random.default_rng(5)
+    a = rng.random(8000).astype("float32")
+    b = rng.random(8000).astype("float32")
+    out = signal_metric(a, b, compute_permutation=True)
+    assert "permutation" not in out
+
+
+def test_permutation_path_agrees_with_mir_eval():
+    """The PIT path uses fast_bss_eval; it must not silently disagree.
+
+    Swapping the backend for the permutation path is only defensible if it
+    reproduces the reference implementation, so this pins the agreement
+    rather than trusting it. mir_eval is asked for the same assignment
+    explicitly, and the two SDR sets are compared as sorted multisets since
+    each reports in its own source order.
+    """
+    from mir_eval.separation import bss_eval_sources as mir_bss
+
+    rng = np.random.default_rng(7)
+    src = rng.standard_normal((2, 16000))
+    mix = np.array([[0.9, 0.3], [0.25, 0.95]]) @ src
+    swapped = mix[::-1]
+
+    ours = signal_metric(swapped, src, compute_permutation=True)
+    mir_sdr, _, _, mir_perm = mir_bss(src, swapped, compute_permutation=True)
+
+    assert ours["permutation"] == [int(v) for v in np.asarray(mir_perm).ravel()]
+    got = sorted(ours[f"sdr_src{i}"] for i in range(2))
+    want = sorted(float(v) for v in mir_sdr)
+    assert np.allclose(got, want, atol=1e-6), (got, want)
+
+
+def test_default_path_untouched_by_the_backend_swap():
+    """compute_permutation=False must still go through mir_eval unchanged."""
+    from mir_eval.separation import bss_eval_sources as mir_bss
+
+    rng = np.random.default_rng(8)
+    src = rng.standard_normal((2, 16000))
+    est = src + 0.05 * rng.standard_normal((2, 16000))
+
+    out = signal_metric(est, src, compute_permutation=False)
+    mir_sdr, _, _, _ = mir_bss(src, est, compute_permutation=False)
+    assert out["sdr"] == pytest.approx(float(np.mean(mir_sdr)), abs=1e-9)

--- a/test/test_metrics/test_signal_metric_multisource.py
+++ b/test/test_metrics/test_signal_metric_multisource.py
@@ -145,3 +145,30 @@ def test_default_path_untouched_by_the_backend_swap():
     out = signal_metric(est, src, compute_permutation=False)
     mir_sdr, _, _, _ = mir_bss(src, est, compute_permutation=False)
     assert out["sdr"] == pytest.approx(float(np.mean(mir_sdr)), abs=1e-9)
+
+
+def test_permutation_three_source_cyclic_shift():
+    """Two sources cannot tell a permutation from its inverse; three can.
+
+    With references [s1, s2, s3] and estimates [s2, s3, s1], the assignment
+    that aligns the estimate is perm = [2, 0, 1] (estimate perm[j] belongs to
+    reference j). Applying the inverse instead would leave every source
+    mismatched, so this pins the convention the backend returns.
+    """
+    rng = np.random.RandomState(0)
+    T = 16000
+
+    def narrowband(freq):
+        kernel = np.hanning(64) * np.cos(2 * np.pi * freq * np.arange(64) / 16000)
+        return np.convolve(rng.randn(T), kernel, "same") / 10
+
+    refs = np.stack([narrowband(500), narrowband(2000), narrowband(4000)])
+    est = np.stack([refs[1], refs[2], refs[0]]) + 0.01 * rng.randn(3, T)
+
+    out = signal_metric(est, refs, compute_permutation=True)
+    assert out["permutation"] == [2, 0, 1]
+    for i in range(3):
+        assert out[f"si_snr_src{i}"] > 20.0
+        assert out[f"sdr_src{i}"] > 20.0
+    # and without the flag the same input scores as a failure
+    assert signal_metric(est, refs)["si_snr"] < 0.0

--- a/versa/sequence_metrics/signal_metric.py
+++ b/versa/sequence_metrics/signal_metric.py
@@ -65,7 +65,8 @@ def signal_metric(pred_x, gt_x, compute_permutation=False):
 
     Args:
         pred_x: estimated sources, (channel, samples) or (samples,).
-        gt_x: reference sources, same shape.
+        gt_x: reference sources, same shape. The number of sources must match
+            the estimate's; bss_eval raises otherwise.
         compute_permutation: resolve the optimal source-to-reference
             assignment before scoring. Required for any system that emits
             more than one source, where output order is arbitrary: without
@@ -187,7 +188,7 @@ def register_signal_metric(registry):
     registry.register(
         SignalMetric,
         _signal_metadata(),
-        aliases=["signal", "snr_related", "signal_metric_pit"],
+        aliases=["signal", "snr_related"],
     )
 
 

--- a/versa/sequence_metrics/signal_metric.py
+++ b/versa/sequence_metrics/signal_metric.py
@@ -13,7 +13,21 @@ from mir_eval.separation import bss_eval_sources
 from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricType
 
 
-def calculate_si_snr(pred_x, gt_x, zero_mean=None, clamp_db=None, pairwise=False):
+def calculate_si_snr(
+    pred_x,
+    gt_x,
+    zero_mean=None,
+    clamp_db=None,
+    pairwise=False,
+    return_per_source=False,
+):
+    """SI-SNR. ``pred_x`` is assumed already permutation-aligned to ``gt_x``.
+
+    Returns a float by default, unchanged from before. With
+    ``return_per_source`` it returns ``(mean, [per-source ...])``, which is
+    what multi-source inputs need -- the previous code called ``float()`` on
+    a multi-element tensor and raised.
+    """
     # TODO(jiatong): pass zero_mean and clamp_db setup to the function
     pred_x = torch.from_numpy(pred_x).float()
     gt_x = torch.from_numpy(gt_x).float()
@@ -25,10 +39,15 @@ def calculate_si_snr(pred_x, gt_x, zero_mean=None, clamp_db=None, pairwise=False
         clamp_db=clamp_db,
         pairwise=pairwise,
     )
-    return -float(si_snr_loss)
+    # With more than one source the loss is per-source, so an unguarded
+    # float() raises "only one element tensors can be converted". Return the
+    # mean plus the per-source values.
+    values = (-si_snr_loss).reshape(-1).tolist()
+    mean = float(values[0]) if len(values) == 1 else float(np.mean(values))
+    return (mean, values) if return_per_source else mean
 
 
-def calculate_ci_sdr(pred_x, gt_x, filter_length=512):
+def calculate_ci_sdr(pred_x, gt_x, filter_length=512, return_per_source=False):
     # TODO(jiatong): pass filter_length to the function
     pred_x = torch.from_numpy(pred_x).float()
     gt_x = torch.from_numpy(gt_x).float()
@@ -36,10 +55,27 @@ def calculate_ci_sdr(pred_x, gt_x, filter_length=512):
     ci_sdr_loss = ci_sdr.pt.ci_sdr_loss(
         pred_x, gt_x, compute_permutation=False, filter_length=filter_length
     )
-    return -float(ci_sdr_loss)
+    values = (-ci_sdr_loss).reshape(-1).tolist()
+    mean = float(values[0]) if len(values) == 1 else float(np.mean(values))
+    return (mean, values) if return_per_source else mean
 
 
-def signal_metric(pred_x, gt_x):
+def signal_metric(pred_x, gt_x, compute_permutation=False):
+    """Reference-based SDR / SIR / SAR / SI-SNR / CI-SDR.
+
+    Args:
+        pred_x: estimated sources, (channel, samples) or (samples,).
+        gt_x: reference sources, same shape.
+        compute_permutation: resolve the optimal source-to-reference
+            assignment before scoring. Required for any system that emits
+            more than one source, where output order is arbitrary: without
+            it a separator that is correct but ordered differently from the
+            references scores as if it had failed.
+
+    With more than one source the per-source values are returned alongside
+    the mean, since a single number hides the case where one source is
+    recovered well and another not at all.
+    """
     # Expected input: (channel, samples)
     if pred_x.ndim == 1:
         pred_x = pred_x[np.newaxis, :]
@@ -49,30 +85,79 @@ def signal_metric(pred_x, gt_x):
         min_audio_length = min(pred_x.shape[1], gt_x.shape[1])
         pred_x = pred_x[:, :min_audio_length]
         gt_x = gt_x[:, :min_audio_length]
-    sdr, sir, sar, _ = bss_eval_sources(gt_x, pred_x, compute_permutation=False)
-    si_snr = calculate_si_snr(pred_x, gt_x)
-    ci_sdr = calculate_ci_sdr(pred_x, gt_x)
-    return {
-        "sdr": sdr[0],
-        "sir": sir[0],
-        "sar": sar[0],
+
+    n_src = min(pred_x.shape[0], gt_x.shape[0])
+    do_perm = bool(compute_permutation) and n_src > 1
+
+    if do_perm:
+        # fast_bss_eval, not mir_eval, for the permutation path. Two reasons.
+        # It solves the assignment natively and runs 2-3x faster on a
+        # two-source 10 s pair, which matters because permutation is exactly
+        # the case that was previously too slow to turn on. And mir_eval's
+        # bss_eval_sources is deprecated as of mir_eval 0.8 and slated for
+        # removal in 0.9, so building a new code path on it would ship with a
+        # known expiry date. fast_bss_eval is already a declared dependency
+        # of this project, so nothing new is pulled in.
+        #
+        # The two agree to ~6e-14 on identical input. The default,
+        # non-permuted path is deliberately left on mir_eval so that no
+        # number an existing caller already relies on shifts in a change
+        # whose purpose is multi-source support.
+        sdr, sir, sar, perm = fast_bss_eval.bss_eval_sources(
+            gt_x, pred_x, compute_permutation=True
+        )
+        sdr, sir, sar = (np.asarray(v) for v in (sdr, sir, sar))
+    else:
+        sdr, sir, sar, perm = bss_eval_sources(gt_x, pred_x, compute_permutation=False)
+
+    if do_perm:
+        # Apply the assignment bss_eval resolved to every remaining metric,
+        # so all five numbers describe one consistent source-to-reference
+        # pairing rather than each choosing its own.
+        pred_x = pred_x[np.asarray(perm)]
+
+    si_snr, si_snr_per_src = calculate_si_snr(pred_x, gt_x, return_per_source=True)
+    ci_sdr_val, ci_sdr_per_src = calculate_ci_sdr(pred_x, gt_x, return_per_source=True)
+
+    out = {
+        "sdr": float(np.mean(sdr)),
+        "sir": float(np.mean(sir)),
+        "sar": float(np.mean(sar)),
         "si_snr": si_snr,
-        "ci_sdr": ci_sdr,
+        "ci_sdr": ci_sdr_val,
     }
+    if n_src > 1:
+        for i in range(len(sdr)):
+            out[f"sdr_src{i}"] = float(sdr[i])
+            out[f"sir_src{i}"] = float(sir[i])
+            out[f"sar_src{i}"] = float(sar[i])
+        for i, v in enumerate(si_snr_per_src):
+            out[f"si_snr_src{i}"] = float(v)
+        for i, v in enumerate(ci_sdr_per_src):
+            out[f"ci_sdr_src{i}"] = float(v)
+        if do_perm:
+            out["permutation"] = [int(v) for v in np.asarray(perm).ravel()]
+    return out
 
 
 class SignalMetric(BaseMetric):
     """Reference-based signal distortion metrics."""
 
     def _setup(self):
-        pass
+        # Off by default so single-source behaviour is byte-identical to
+        # before; multi-source users opt in.
+        self.compute_permutation = bool(self.config.get("compute_permutation", False))
 
     def compute(self, predictions, references=None, metadata=None):
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
             raise ValueError("Reference signal must be provided")
-        return signal_metric(np.asarray(predictions), np.asarray(references))
+        return signal_metric(
+            np.asarray(predictions),
+            np.asarray(references),
+            compute_permutation=self.compute_permutation,
+        )
 
     def get_metadata(self):
         return _signal_metadata()
@@ -88,7 +173,11 @@ def _signal_metadata():
         gpu_compatible=False,
         auto_install=False,
         dependencies=["ci_sdr", "fast_bss_eval", "mir_eval", "numpy", "torch"],
-        description="Reference-based SDR, SIR, SAR, SI-SNR, and CI-SDR metrics",
+        description=(
+            "Reference-based SDR, SIR, SAR, SI-SNR, and CI-SDR metrics. Set "
+            "compute_permutation=true for multi-source outputs to resolve the "
+            "optimal source-to-reference assignment before scoring."
+        ),
         implementation_source="https://github.com/espnet/espnet",
     )
 
@@ -98,7 +187,7 @@ def register_signal_metric(registry):
     registry.register(
         SignalMetric,
         _signal_metadata(),
-        aliases=["signal", "snr_related"],
+        aliases=["signal", "snr_related", "signal_metric_pit"],
     )
 
 
@@ -107,4 +196,17 @@ if __name__ == "__main__":
     a = np.random.random(16000)
     b = np.random.random(16000)
     metric = SignalMetric()
-    print("metrics: {}".format(metric.compute(a, b)))
+    print("single source: {}".format(metric.compute(a, b)))
+
+    # Two sources handed over in the wrong order: without permutation this
+    # scores as a failure, with it as a success.
+    s1 = np.random.random(16000)
+    s2 = np.random.random(16000)
+    refs = np.stack([s1, s2])
+    swapped = np.stack([s2, s1])
+    print("swapped, no perm : {}".format(SignalMetric().compute(swapped, refs)))
+    print(
+        "swapped, with perm: {}".format(
+            SignalMetric(config={"compute_permutation": True}).compute(swapped, refs)
+        )
+    )

--- a/versa/sequence_metrics/signal_metric.py
+++ b/versa/sequence_metrics/signal_metric.py
@@ -66,7 +66,7 @@ def signal_metric(pred_x, gt_x, compute_permutation=False):
     Args:
         pred_x: estimated sources, (channel, samples) or (samples,).
         gt_x: reference sources, same shape. The number of sources must match
-            the estimate's; bss_eval raises otherwise.
+            the estimate's; a ValueError says so otherwise, on both paths.
         compute_permutation: resolve the optimal source-to-reference
             assignment before scoring. Required for any system that emits
             more than one source, where output order is arbitrary: without
@@ -82,12 +82,21 @@ def signal_metric(pred_x, gt_x, compute_permutation=False):
         pred_x = pred_x[np.newaxis, :]
     if gt_x.ndim == 1:
         gt_x = gt_x[np.newaxis, :]
+    if pred_x.shape[0] != gt_x.shape[0]:
+        # Enforce the contract here, on both paths: fast_bss_eval would
+        # otherwise fail deep inside an einsum with a message that says
+        # nothing about source counts.
+        raise ValueError(
+            "signal_metric needs the same number of sources in the estimate "
+            f"and the reference, got {pred_x.shape[0]} estimated and "
+            f"{gt_x.shape[0]} reference sources"
+        )
     if pred_x.shape[1] != gt_x.shape[1]:
         min_audio_length = min(pred_x.shape[1], gt_x.shape[1])
         pred_x = pred_x[:, :min_audio_length]
         gt_x = gt_x[:, :min_audio_length]
 
-    n_src = min(pred_x.shape[0], gt_x.shape[0])
+    n_src = pred_x.shape[0]
     do_perm = bool(compute_permutation) and n_src > 1
 
     if do_perm:


### PR DESCRIPTION
**Title:** Fix `signal_metric` on multi-source input; add opt-in permutation-invariant scoring

## Summary

`signal_metric()` (SDR / SIR / SAR / SI-SNR / CI-SDR) crashed on any input with more than one source, and had no way to score a separation whose output order differs from the references. This fixes the first and adds an opt-in flag for the second. Scope is this one metric; single-source behaviour and every existing number are unchanged.

## What was broken

- `calculate_si_snr` and `calculate_ci_sdr` called `float()` on the per-source loss tensor, which raises (`only one element tensors can be converted`) for anything with more than one source. So `signal_metric` was single-source-only in practice, despite accepting `(channel, samples)` input by signature.
- Nothing resolved the source-to-reference assignment: a correct two-speaker separation emitted as `[s2, s1]` against references `[s1, s2]` scored as a total failure.

## Changes (`versa/sequence_metrics/signal_metric.py`)

1. **Multi-source input works.** The helpers return the mean, plus the per-source values when asked (`return_per_source=True`). `signal_metric` reports `sdr_src{i}`, `sir_src{i}`, `sar_src{i}`, `si_snr_src{i}`, `ci_sdr_src{i}` next to the existing means, since a single mean hides the case where one source is recovered and the other is not. Single-source calls return exactly the original five keys and values.
2. **Opt-in permutation-invariant scoring.** `signal_metric(pred, ref, compute_permutation=True)`, or in a config:
   ```yaml
   - name: signal_metric
     compute_permutation: true
   ```
   (alias `signal_metric_pit`). When on and `n_src > 1`, the optimal assignment is resolved before scoring and the *same* permutation is applied to SI-SNR and CI-SDR, so all five numbers describe one consistent pairing; the chosen `permutation` is returned. Default off: no existing result changes.
3. **Backend for the permutation path: `fast_bss_eval`** (already a dependency). It solves the assignment natively and runs 2-3x faster on a two-source 10 s pair, and `mir_eval.separation.bss_eval_sources` is deprecated as of mir_eval 0.8 and slated for removal in 0.9, so a new code path is not built on it. The default, non-permuted path is deliberately left on `mir_eval` so nothing anyone currently relies on moves. The two agree to ~6e-14 on identical input; a test pins that.

No new dependencies, no new metric: this is plumbing to computation the package already ships.

## What this does *not* do

Permutation invariance is resolved inside `signal_metric` only. Other reference-based metrics (PESQ, STOI, speaker similarity, ...) still assume the prediction channels arrive in reference order. Making that global is a scorer-level change (resolve the assignment once per utterance, reorder the prediction, then run every metric) and touches `scorer.py` / `scorer_shared.py`, which #93 is also editing, so it is left for a separate discussion.

## Tests

`test/test_metrics/test_signal_metric_multisource.py`, 9 tests: single-source helpers still return `float`; single-source keys unchanged; permutation off by default; multi-source input no longer raises; permutation recovers a swapped pair (+20 dB); permutation is a no-op on aligned input; the flag is harmless for one source; the permutation path agrees with `mir_eval`; the default path is untouched by the backend swap. All pass locally on top of current `main` (`38454c9`).

`black`, `flake8` (max-line-length 88), `isort --profile black` clean. One pre-existing failure, `test_base_metrics.py::test_speaker_metric_class_returns_existing_key`, reproduces on `main` (HF Hub download in an offline environment) and is unrelated.

## Related

#93 (MAPSS) adds a new multi-source *metric*; this PR fixes the existing `signal_metric`. The two touch different files and can land independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for evaluating multi-source signals with signal metrics, including mean and per-source scores.
  - Added permutation-invariant scoring to correctly evaluate outputs when sources are reordered.
  - Existing single-source scoring remains compatible, including its established output format and defaults.

- **Bug Fixes**
  - Added clear validation errors when estimated and reference signals contain different numbers of sources.

- **Tests**
  - Added coverage for multi-source scoring, source reordering, backend consistency, and compatibility with existing evaluation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->