### PR TITLE
Document metric contracts and enforce 80% docstring coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .[dev]
+        # Match the formatter revision in .pre-commit-config.yaml.
+        pip install -e .[dev] black==25.1.0
         
     - name: Check formatting
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,16 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   docstring-coverage:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v7
@@ -33,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Set up Python
       uses: actions/setup-python@v7
@@ -64,6 +71,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
         
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v7
@@ -85,6 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
+      with:
+        persist-credentials: false
         
     - name: Set up Python
       uses: actions/setup-python@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,30 @@ on:
     branches: [ main ]
 
 jobs:
+  docstring-coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Python
+      uses: actions/setup-python@v7
+      with:
+        python-version: '3.10'
+
+    - name: Install static documentation checkers
+      run: python -m pip install -r ci/requirements-docstrings.txt
+
+    - name: Interrogate package docstrings
+      run: interrogate --verbose --verbose --fail-under 80 versa
+
+    - name: Cross-check package docstrings
+      if: ${{ !cancelled() }}
+      run: docstr-coverage --include-setter --include-deleter --fail-under 80 versa
+
+    - name: Check function-only docstrings
+      if: ${{ !cancelled() }}
+      run: python ci/check_function_docstrings.py --fail-under 80 versa
+
   code-quality:
     runs-on: ubuntu-latest
     steps:
@@ -73,4 +97,4 @@ jobs:
         
     - name: Run core tests
       run: |
-        pytest -q test/test_metrics/test_definition.py
+        pytest -q test/test_metrics/test_definition.py test/test_docstring_check.py

--- a/ci/check_function_docstrings.py
+++ b/ci/check_function_docstrings.py
@@ -1,0 +1,57 @@
+"""Count actual Python function nodes without class/module coverage heuristics."""
+
+import argparse
+import ast
+from pathlib import Path
+
+
+def function_inventory(path):
+    """Yield (line, qualified name, documented) for every function in one file.
+
+    Include async functions, constructors, private methods, and nested functions.
+    Require a nonempty literal docstring on the definition itself; inherited or
+    dynamically assigned documentation does not count. Syntax errors propagate.
+    """
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+    def walk(node, parents=()):
+        """Track lexical class/function names while visiting every AST child."""
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            parents = parents + (node.name,)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node.lineno, ".".join(parents), bool(ast.get_docstring(node))
+        for child in ast.iter_child_nodes(node):
+            yield from walk(child, parents)
+
+    yield from walk(tree)
+
+
+def main():
+    """Print missing function locations and fail below the requested percentage."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="*", type=Path, default=[Path("versa")])
+    parser.add_argument("--fail-under", type=float, default=80.0)
+    args = parser.parse_args()
+    if not 0 <= args.fail_under <= 100:
+        parser.error("--fail-under must be between 0 and 100")
+    files = set()
+    for path in args.paths:
+        if not path.exists():
+            parser.error(f"path does not exist: {path}")
+        files.update(path.rglob("*.py") if path.is_dir() else [path])
+    total = covered = 0
+    for path in sorted(files):
+        for line, name, documented in function_inventory(path):
+            total += 1
+            covered += documented
+            if not documented:
+                print(f"{path}:{line}: missing {name}")
+    if not total:
+        parser.error("no Python functions found")
+    percent = 100 * covered / total
+    print(f"Function docstrings: {covered}/{total} ({percent:.2f}%)")
+    return 0 if percent >= args.fail_under else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/requirements-docstrings.txt
+++ b/ci/requirements-docstrings.txt
@@ -1,0 +1,3 @@
+# Static checks only: no VERSA model dependencies are needed.
+interrogate==1.7.0
+docstr-coverage==2.3.2

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,6 +9,8 @@ The CI workflow is defined in `.github/workflows/ci.yml` and consists of several
 1. **Code Quality**: Checks code formatting with Black and linting with Flake8
 2. **Installation Tests**: Tests the lean package install across Python versions
 3. **Core Tests**: Runs dependency-light registry and scoring unit tests
+4. **Docstring Coverage**: Runs pinned Interrogate and docstr-coverage package
+   checks plus an AST-based function-only check, each with an 80% minimum
 
 Full metric tests are intentionally not part of the default CI path because many
 metrics require large models, Git dependencies, or external toolkits. Run those
@@ -46,6 +48,29 @@ pytest test/test_general.py
 pytest test/test_metrics/test_stoi.py
 pytest test/test_metrics/test_pesq.py
 ```
+
+### Docstring Coverage
+
+The independent `docstring-coverage` job installs only
+`ci/requirements-docstrings.txt`; it does not import VERSA or download models.
+Run the same checks locally:
+
+```bash
+python -m pip install -r ci/requirements-docstrings.txt
+interrogate --verbose --verbose --fail-under 80 versa
+docstr-coverage --include-setter --include-deleter --fail-under 80 versa
+python ci/check_function_docstrings.py --fail-under 80 versa
+```
+
+All files under `versa/`, including bundled model helpers, remain in scope.
+Private methods, constructors, nested and async functions count. There are no
+coverage exclusions or inherited-docstring exemptions. The AST check prints
+each missing function's path, line, and qualified name and compares the unrounded
+percentage to the threshold. Its parser/counting contracts run in core tests.
+
+CodeRabbit's PR check measures changed functions and can report a different
+percentage. It remains separate from these package-wide gates and from pytest
+execution coverage. See [the audit and checker survey](docstring_coverage.md).
 
 ### Real Model Cache Setup
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -80,6 +80,16 @@ strict dependency versions, prefer:
 
 ### Step 4: Add Docs and Examples
 
+Document each new or changed function, including private helpers, constructors,
+and test fixtures. A short behavioral summary is enough for a simple adapter;
+avoid docstrings that only repeat the function name. For metric `compute` methods,
+describe waveform dimensions and channel handling, sample-rate source and default,
+required references/text, output keys and units/direction, and failure behavior.
+For `_setup` and persistence helpers, describe downloads, cache changes, file
+ownership, and resume behavior. Keep existing docstrings accurate when behavior
+changes. See `MapssMetric.compute`, `StoiMetric.compute`, and
+`LogWmseMetric.compute` for concrete examples.
+
 Update `docs/supported_metrics.md` with the new metric. Mark the Auto-Install
 column according to whether the base installation provides all required
 dependencies.
@@ -123,3 +133,21 @@ dependencies installed, you can run:
 ```bash
 pre-commit run --all-files
 ```
+
+Run the documentation checks from the repository root (no model installation
+required):
+
+```bash
+python -m pip install -r ci/requirements-docstrings.txt
+interrogate --verbose --verbose --fail-under 80 versa
+docstr-coverage --include-setter --include-deleter --fail-under 80 versa
+python ci/check_function_docstrings.py --fail-under 80 versa
+```
+
+All three checks must pass at 80% or higher. Their output identifies missing
+definitions. The two package checks include modules, classes, constructors,
+private/nested functions, and bundled model code under `versa/`; the last check
+counts only actual function definitions. CodeRabbit separately checks functions
+touched by a PR, including files outside `versa/`. Package coverage does not
+replace that review. See [the coverage audit](docstring_coverage.md) for scope,
+baseline results, and checker differences.

--- a/docs/docstring_coverage.md
+++ b/docs/docstring_coverage.md
@@ -1,0 +1,126 @@
+# Docstring coverage audit
+
+Audited 2026-09-11 against checkout `bf8804f` plus this documentation change.
+
+## Recent automated review findings
+
+The warnings are from **CodeRabbit**, not pytest coverage or a locally configured
+Python linter. The latest walkthrough comments retrieved during this audit say:
+
+| PR | Reported coverage | Analyzed scope | Comment updated (UTC) |
+| --- | ---: | --- | --- |
+| [#96: Reclaim code entropy](https://github.com/wavlab-speech/versa/pull/96#issuecomment-5615048983) | 26.39% | 72 touched functions, 33 files; one unsupported file skipped | 2026-09-10 08:00 |
+| [#93: MAPSS integration](https://github.com/wavlab-speech/versa/pull/93#issuecomment-5593556287) | 24.39% | 41 touched functions, 9 files | 2026-09-09 10:53 |
+| [#95: Multi-source signal metrics](https://github.com/wavlab-speech/versa/pull/95#issuecomment-5609504597) | 68.42% | 19 touched functions, 2 files | 2026-09-09 23:56 |
+
+All require 80%. The current #93 comment supersedes an earlier recorded
+24.32% / 37-function result. These are mutable comments: their update timestamps
+are not proof of the exact source revision evaluated. They do not publish a
+checker version, evaluation base/head pair, or function-by-function inventory.
+The local measurements below therefore do not reproduce or replace these bot
+results. A new CodeRabbit review on a published head is needed to verify its
+current diff-specific gate; no review was requested or PR posted in this audit.
+
+CodeRabbit documents its check as applying to functions touched by the diff.
+This explains why documentation of test helpers and script adapters matters in
+addition to library APIs. [CodeRabbit pre-merge checks](https://docs.coderabbit.ai/pr-reviews/pre-merge-checks)
+
+PR #95's multi-source changes are not in this checkout. The existing
+`signal_metric` documentation explicitly describes its scalar, single-source
+limitation rather than promising that PR's permutation support.
+
+## Reproduced local results
+
+Both third-party tools were run from an isolated environment with pinned versions.
+The baseline was reconstructed from tracked Python files at `bf8804f`.
+
+| Check | Baseline | Updated | Threshold |
+| --- | ---: | ---: | ---: |
+| Interrogate 1.7.0, full package | 461 / 1024 = 45.0% | 854 / 1024 = 83.4% | 80% |
+| docstr-coverage 2.3.2, full package | 461 / 1019 = 45.2% | 854 / 1023 = 83.5% | 80% |
+| Python AST, functions only | 301 / 792 = 38.01% | 636 / 792 = 80.30% | 80% |
+
+Scope is **all 78 Python files under `versa/`**, including the bundled NISQA,
+NORESQA, and PAM implementations. No paths, private functions, constructors,
+nested functions, or magic methods were excluded to reach the target. Setter
+and deleter checks are explicitly enabled for docstr-coverage. Tests and scripts
+are outside these package totals, but the missing function docstrings in files
+associated with #93 and #96 were also addressed.
+
+For an additional local inventory, the current versions of the 33 Python files
+changed between `caf9cbe` and `bf8804f` (#96) have **328/328** documented functions.
+The eight Python files changed by merge `caf9cbe` relative to its first parent
+(#93) have **122/122**. These count every current function in those files, not
+only changed functions; deleted definitions are absent. They are deliberately
+not labeled as reproductions of CodeRabbit's 72- and 41-function denominators.
+
+The package gained 393 literal docstrings, including 335 function docstrings.
+The differing totals come from checker semantics: Interrogate counts empty
+modules, while docstr-coverage omits them. Four previously empty package
+initializers now contain documentation, increasing the latter denominator.
+
+The third-party measurements used Python 3.14; regression tests used Python 3.12.
+CI runs the static checks on Python 3.10 without installing model dependencies.
+
+## What to document
+
+Prioritize the contract a caller cannot infer from a function name:
+
+- **Metric compute methods:** waveform axes, channel selection/mixing, sample-rate
+  defaults, alignment, required references/text, output keys and units, numerical
+  limitations, and errors. Examples: MAPSS source order and diagnostic artifacts;
+  LogWMSE's configured model rate; WER edit counts versus normalized error rates.
+- **Setup and cache helpers:** optional dependencies, downloads, device selection,
+  global cache changes, and local/offline asset behavior.
+- **Scoring and reporting:** file ownership, append/resume behavior, dispatch,
+  missing/nonfinite values, score-direction heuristics, and report overwrites.
+- **Registry/discovery:** metadata extraction without model imports, aliases,
+  configuration inspection, and lazy runtime loading.
+- **Tests and adapters:** the invariant asserted, fake backend behavior, or the
+  compatibility contract being preserved. Short summaries are sufficient here.
+
+The remaining missing functions are in bundled model internals; the AST check
+prints their exact file, line, and qualified name. Coverage establishes presence,
+not correctness or completeness. Review the documentation alongside the code.
+
+## Checker survey and selection
+
+| Source | Useful for | Limitation / decision |
+| --- | --- | --- |
+| [Interrogate](https://interrogate.readthedocs.io/en/latest/) | Static package inventory, detailed missing-definition reports, percentage gate | Selected at 1.7.0 with default separate class/constructor counting and no ignore flags. |
+| [docstr-coverage](https://github.com/HunterMcGushion/docstr_coverage) | Independent package inventory and percentage gate | Selected at 2.3.2 with setters/deleters included; empty modules differ from Interrogate. |
+| [Ruff D103 / pydocstyle rules](https://docs.astral.sh/ruff/rules/undocumented-public-function/) | Missing public-function documentation and docstring style rules | Useful future style linting; not an interchangeable package coverage percentage. |
+| Python `ast` inventory in `ci/check_function_docstrings.py` | Explicit count of actual function/async-function nodes | Selected as the function-only gate; counts literal, nonempty docstrings, including nested/private definitions. Does not infer inherited documentation. |
+| CodeRabbit | Existing PR changed-function gate | Keep separate; its published comments do not expose an exact local reproduction recipe. |
+
+A relevant 2.3.2 implementation quirk: docstr-coverage's `--skip-class-def` uses
+name capitalization rather than the AST node type, and `--skip-file-doc` can
+still count documented modules. Those options changed the denominator during
+this audit and were **not** used as a true function-only gate. The small AST
+counter avoids that ambiguity. See the pinned implementation's
+[node filtering](https://github.com/HunterMcGushion/docstr_coverage/blob/v2.3.2/docstr_coverage/coverage.py)
+and module collection logic.
+
+## Repeat the checks
+
+Run from the repository root in a Python environment:
+
+```bash
+python -m pip install -r ci/requirements-docstrings.txt
+interrogate --verbose --verbose --fail-under 80 versa
+docstr-coverage --include-setter --include-deleter --fail-under 80 versa
+python ci/check_function_docstrings.py --fail-under 80 versa
+```
+
+All three commands fail below 80%. The workflow runs both cross-checks even if
+the first check fails, so their missing-definition reports remain visible.
+The AST counter also accepts individual Python files or directories for a
+focused inventory, but it is not a reproduction of CodeRabbit's diff selection.
+
+Validation: 118 tests passed across the regression selection and counter/cache
+checks, with one optional real-model test skipped. The new counter has tests for
+nested/async/private/init counting, exact threshold behavior, and empty-input
+rejection. All 177 tracked Python files passed Black; blocking Flake8 checks
+and `git diff --check` passed. Executable ASTs of all 74 existing modified Python
+files were compared with HEAD after removing only literal docstrings; scoring,
+signatures, and test behavior are unchanged.

--- a/scripts/postprocess/qwen2_audio_json_output_standardizer.py
+++ b/scripts/postprocess/qwen2_audio_json_output_standardizer.py
@@ -50,12 +50,15 @@ class JsonOutputStandardizer:
     """
 
     def _translate_non_english(self, text):
+        """Translate known terms using this standardizer instance translation dictionary."""
         return translate_non_english(text, self.translation_dict)
 
     def _process_llm_output(self, metric_name, llm_output):
+        """Clean an LLM response using this instance schema and the shared output rules."""
         return process_llm_output(metric_name, llm_output, self.expected_formats)
 
     def _rules_based_standardize(self, metric_name, raw_output):
+        """Apply deterministic category and numeric rules using this instance schema."""
         return rules_based_standardize(
             metric_name, raw_output, self.expected_formats, self.translation_dict
         )
@@ -325,6 +328,7 @@ def process_directory(input_dir, output_dir=None, use_llm=True, file_pattern="*.
 
 
 def main():
+    """Parse CLI inputs, configure the standardizer, and write normalized output files."""
     parser = argparse.ArgumentParser(description="Standardize Qwen2-Audio JSON outputs")
     parser.add_argument("input", help="Input JSON file or directory")
     parser.add_argument(

--- a/scripts/postprocess/qwen2_audio_jsonl_standardizer_batch.py
+++ b/scripts/postprocess/qwen2_audio_jsonl_standardizer_batch.py
@@ -107,12 +107,15 @@ class BatchInferenceStandardizer:
     """
 
     def _translate_non_english(self, text):
+        """Translate known terms using this standardizer instance translation dictionary."""
         return translate_non_english(text, self.translation_dict)
 
     def _process_llm_output(self, metric_name, llm_output):
+        """Clean an LLM response using this instance schema and the shared output rules."""
         return process_llm_output(metric_name, llm_output, self.expected_formats)
 
     def _rules_based_standardize(self, metric_name, raw_output):
+        """Apply deterministic category and numeric rules using this instance schema."""
         return rules_based_standardize(
             metric_name, raw_output, self.expected_formats, self.translation_dict
         )
@@ -544,6 +547,7 @@ def process_directory(input_dir, output_dir, file_pattern="*.jsonl", batch_size=
 
 
 def main():
+    """Parse CLI inputs, configure the standardizer, and write normalized output files."""
     parser = argparse.ArgumentParser(
         description="Standardize Qwen2-Audio JSONL outputs with batch inference"
     )

--- a/test/test_docstring_check.py
+++ b/test/test_docstring_check.py
@@ -1,0 +1,62 @@
+"""Check function coverage semantics independently of model dependencies."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+from ci.check_function_docstrings import function_inventory
+
+
+CHECKER = Path(__file__).resolve().parents[1] / "ci/check_function_docstrings.py"
+
+
+def test_inventory_includes_nested_async_private_and_init(tmp_path):
+    """Class docs must not cover methods; nested and async functions count separately."""
+    source = tmp_path / "sample.py"
+    source.write_text(
+        '"""Module docs."""\n'
+        "class Example:\n"
+        '    """Class docs."""\n'
+        "    def __init__(self):\n"
+        "        pass\n"
+        "    async def _run(self):\n"
+        '        """Run the operation."""\n'
+        "        def nested():\n"
+        '            """"""\n'
+        "            return 1\n"
+        "        return nested()\n"
+    )
+    assert list(function_inventory(source)) == [
+        (4, "Example.__init__", False),
+        (6, "Example._run", True),
+        (8, "Example._run.nested", False),
+    ]
+
+
+def test_cli_enforces_exact_threshold(tmp_path):
+    """Three documented functions out of four fail at 80% and pass at 75%."""
+    source = tmp_path / "sample.py"
+    source.write_text(
+        "\n".join(
+            f'def f{i}():\n    """Return {i}."""\n    return {i}' for i in range(3)
+        )
+        + "\ndef missing():\n    pass\n"
+    )
+    for threshold, expected in [(80, 1), (75, 0)]:
+        result = subprocess.run(
+            [sys.executable, str(CHECKER), str(source), "--fail-under", str(threshold)],
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == expected
+        assert "3/4 (75.00%)" in result.stdout
+        assert "missing missing" in result.stdout
+
+
+def test_cli_rejects_empty_inventory(tmp_path):
+    """An empty directory cannot produce a misleading passing coverage result."""
+    result = subprocess.run(
+        [sys.executable, str(CHECKER), str(tmp_path)], text=True, capture_output=True
+    )
+    assert result.returncode == 2
+    assert "no Python functions found" in result.stderr

--- a/test/test_metrics/test_emo_similarity.py
+++ b/test/test_metrics/test_emo_similarity.py
@@ -10,8 +10,13 @@ from versa.utterance_metrics.emo_similarity import Emo2vecMetric, is_emo2vec_ava
 
 
 def test_emotion_metric_warns_for_low_sample_rate(caplog):
+    """Warn on low-rate embedding comparison while preserving the similarity result."""
+
     class DummyModel:
+        """Return a fixed embedding to isolate the sample-rate warning."""
+
         def extract_feature(self, audio, fs=16000):
+            """Return a unit embedding without model inference or downloads."""
             return np.asarray([1.0, 0.0], dtype=np.float32)
 
     metric = object.__new__(Emo2vecMetric)

--- a/test/test_metrics/test_mapss.py
+++ b/test/test_metrics/test_mapss.py
@@ -1,3 +1,5 @@
+"""MAPSS source ordering, optional dependency, and artifact contract tests."""
+
 from types import SimpleNamespace
 
 import numpy as np
@@ -9,16 +11,23 @@ from versa.utterance_metrics import mapss
 
 
 class FakeSummary:
+    """Provide the indexed-table interface consumed by MAPSS summary conversion."""
+
     def __init__(self, rows):
+        """Retain source rows for conversion without requiring pandas."""
         self.rows = rows
 
     def to_dict(self, orient):
+        """Return source rows and assert the requested index orientation."""
         assert orient == "index"
         return self.rows
 
 
 class FakeResult:
+    """Supply fixed source summaries and record diagnostic-save requests."""
+
     def __init__(self):
+        """Create two source summaries with frame counts and an empty save record."""
         self.summary = FakeSummary(
             {
                 "Vocals": {"ps": 0.75, "pm": 0.8, "ps_frames": 10, "pm_frames": 9},
@@ -28,16 +37,19 @@ class FakeResult:
         self.saved = None
 
     def save(self, directory, plot):
+        """Record the requested artifact directory and plot flag without writing files."""
         self.saved = (directory, plot)
 
 
 def test_mapss_metric_forwards_ordered_sources_and_retains_frames(
     monkeypatch, tmp_path
 ):
+    """Verify source lists reach MAPSS unchanged and diagnostic artifacts are retained."""
     call = SimpleNamespace(kwargs=None)
     result = FakeResult()
 
     def fake_mapss(**kwargs):
+        """Record backend arguments and return the fixed diagnostic result."""
         call.kwargs = kwargs
         return result
 
@@ -90,6 +102,7 @@ def test_mapss_metric_forwards_ordered_sources_and_retains_frames(
 def test_mapss_metric_validates_source_pairs(
     monkeypatch, predictions, references, message
 ):
+    """Reject too few sources or mismatched prediction/reference source counts."""
     monkeypatch.setattr(mapss, "mapss_compute", lambda **kwargs: FakeResult())
     metric = mapss.MapssMetric()
 
@@ -98,6 +111,7 @@ def test_mapss_metric_validates_source_pairs(
 
 
 def test_mapss_setup_reports_missing_optional_dependency(monkeypatch):
+    """Expose installer guidance when MAPSS is unavailable."""
     monkeypatch.setattr(mapss, "mapss_compute", None)
 
     with pytest.raises(ImportError, match=r"tools/install_mapss\.sh"):
@@ -105,6 +119,7 @@ def test_mapss_setup_reports_missing_optional_dependency(monkeypatch):
 
 
 def test_mapss_registration_metadata():
+    """Verify aliases resolve to the optional multi-source metric and its requirements."""
     registry = MetricRegistry()
 
     mapss.register_mapss_metric(registry)
@@ -122,6 +137,7 @@ def test_mapss_registration_metadata():
 
 
 def test_mapss_is_discoverable_without_optional_backend():
+    """Expose MAPSS metadata through source discovery without loading its backend."""
     registry = create_metric_discovery_registry()
 
     metadata = registry.get_metadata("mapss")
@@ -133,6 +149,7 @@ def test_mapss_is_discoverable_without_optional_backend():
 
 
 def test_mapss_rejects_colliding_normalized_source_names():
+    """Reject distinct source labels that would produce identical result keys."""
     summary = FakeSummary(
         {
             "lead vocal": {"ps": 1, "pm": 1, "ps_frames": 1, "pm_frames": 1},

--- a/test/test_metrics/test_nomad.py
+++ b/test/test_metrics/test_nomad.py
@@ -125,6 +125,7 @@ class TestNomadMetric:
 
     @patch("versa.utterance_metrics.nomad.Nomad")
     def test_cache_dir_takes_precedence_over_legacy_model_cache(self, mock_nomad_class):
+        """Prefer the shared cache_dir over the legacy model_cache option."""
         mock_nomad_class.return_value = Mock()
 
         NomadMetric(

--- a/test/test_metrics/test_pam.py
+++ b/test/test_metrics/test_pam.py
@@ -12,10 +12,14 @@ from versa.utterance_metrics.pam import PamMetric, PAM, is_pam_available
 
 
 def test_pam_metric_forwards_cache_dir(monkeypatch, tmp_path):
+    """Forward the configured shared cache path into the PAM backend."""
     calls = {}
 
     class DummyPam:
+        """Capture PAM initialization arguments without loading its model."""
+
         def __init__(self, **kwargs):
+            """Record backend keyword arguments for cache-forwarding assertions."""
             calls.update(kwargs)
 
     monkeypatch.setenv("VERSA_HF_CACHE_DIR", "")

--- a/test/test_metrics/test_review_input_guards.py
+++ b/test/test_metrics/test_review_input_guards.py
@@ -1,0 +1,64 @@
+"""Regression checks for invalid collections and nonmatching reference audio."""
+
+import importlib
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name,class_name",
+    [
+        ("fad", "FadMetric"),
+        ("individual_fad", "IndividualFadMetric"),
+        ("kid", "KidMetric"),
+    ],
+)
+@pytest.mark.parametrize("source", ["references", "metadata", "config", "predictions"])
+def test_empty_collections_rejected_before_backend(module_name, class_name, source):
+    """Empty explicit inputs must not fall through to another baseline or backend."""
+    module = importlib.import_module(f"versa.corpus_metrics.{module_name}")
+    metric = object.__new__(getattr(module, class_name))
+    metric.io = "dir"
+    metric.baseline = {"a": "a.wav", "b": "b.wav"}
+    metric.module = Mock()
+    metric.cache_dir = "unused"
+    metric.use_inf = False
+    references = None
+    metadata = {}
+    predictions = {"p": "p.wav", "q": "q.wav"}
+    if source == "references":
+        references = {}
+        metadata["baseline_files"] = metric.baseline
+    elif source == "metadata":
+        metadata["baseline_files"] = {}
+    elif source == "config":
+        metric.baseline = {}
+    else:
+        predictions = {}
+    with pytest.raises(ValueError, match="non-empty|at least 2"):
+        metric.compute(predictions, references, metadata)
+    assert metric.module.mock_calls == []
+
+
+@pytest.mark.parametrize("test_length", [0, 4])
+def test_noresqa_empty_reference_rejected(test_length):
+    """Reject an empty reference before attempting to repeat it."""
+    from versa.utterance_metrics.noresqa_utils.noresqa_utils import check_size
+
+    with pytest.raises(ValueError, match="non-empty reference"):
+        check_size(np.array([]), np.zeros(test_length))
+
+
+@pytest.mark.parametrize(
+    "length,expected", [(1, [1]), (2, [1, 2]), (5, [1, 2, 1, 2, 1])]
+)
+def test_noresqa_reference_duration_adjustment(length, expected):
+    """Preserve truncation, equal durations, and repetition for valid references."""
+    from versa.utterance_metrics.noresqa_utils.noresqa_utils import check_size
+
+    audio_test = np.zeros(length)
+    reference, result = check_size(np.array([1, 2]), audio_test)
+    np.testing.assert_array_equal(reference, expected)
+    assert result is audio_test

--- a/test/test_metrics/test_shared_metadata.py
+++ b/test/test_metrics/test_shared_metadata.py
@@ -19,6 +19,7 @@ from versa import metric_metadata
 
 @pytest.mark.parametrize("family", ["qwen2_audio", "qwen_omni", "squim", "scoreq"])
 def test_runtime_registration_matches_source_discovery(family):
+    """Compare real registration with AST discovery using model-free placeholder classes."""
     path = (
         Path(__file__).resolve().parents[2]
         / "versa/utterance_metrics"
@@ -63,6 +64,7 @@ def test_runtime_registration_matches_source_discovery(family):
 
 
 def test_discovery_cli_does_not_import_model_stacks():
+    """Run discovery in a fresh process that rejects heavy model imports."""
     code = """
 import sys
 sys.argv = ["versa-score", "--list-metrics"]
@@ -90,6 +92,7 @@ main()
 @pytest.mark.parametrize("task", sorted(_RECOMMENDED_CONFIGS))
 @pytest.mark.parametrize("device", ["cpu", "gpu"])
 def test_recommendation_values_and_header(task, device):
+    """Check YAML recommendation values and their task/device header against the source."""
     result = recommend_config(task, device)
     assert result.startswith(
         f"# Recommended VERSA score config for task={task}, device={device}\n"

--- a/test/test_metrics/test_shared_metadata.py
+++ b/test/test_metrics/test_shared_metadata.py
@@ -98,3 +98,24 @@ def test_recommendation_values_and_header(task, device):
         f"# Recommended VERSA score config for task={task}, device={device}\n"
     )
     assert yaml.safe_load(result) == _RECOMMENDED_CONFIGS[task][device]
+
+
+def test_asr_match_dictionary_type_matches_runtime_and_discovery():
+    """Expose the multi-field ASR result in dictionary-filtered metric listings."""
+    from versa.definition import MetricType
+    from versa.utterance_metrics.asr_matching import (
+        ASRMatchMetric,
+        register_asr_match_metric,
+    )
+
+    registry = MetricRegistry()
+    register_asr_match_metric(registry)
+    assert registry.list_metrics(metric_type=MetricType.DICT) == ["asr_match"]
+    assert registry.list_metrics(metric_type=MetricType.FLOAT) == []
+    metric = object.__new__(ASRMatchMetric)
+    assert metric.get_metadata() == registry.get_metadata("asr_match")
+    path = (
+        Path(__file__).resolve().parents[2] / "versa/utterance_metrics/asr_matching.py"
+    )
+    discovered = dict((item.name, item) for item, _ in _discover_module_metadata(path))
+    assert discovered["asr_match"].metric_type == MetricType.DICT

--- a/test/test_pipeline/test_mapss_pipeline.py
+++ b/test/test_pipeline/test_mapss_pipeline.py
@@ -1,3 +1,5 @@
+"""Ordered multi-source CLI validation and result persistence contracts."""
+
 import json
 import sys
 from dataclasses import replace
@@ -22,16 +24,21 @@ from versa.scorer_shared import VersaScorer, find_files
 
 
 class OrderedSourceMetric(BaseMetric):
+    """Record ordered source calls while returning a deterministic source-count score."""
+
     calls = []
 
     def _setup(self):
+        """Avoid loading a model for the pipeline contract tests."""
         pass
 
     def compute(self, predictions, references=None, metadata=None):
+        """Record waveforms and metadata, then return the predicted source count."""
         self.calls.append((predictions, references, metadata))
         return {"ordered_source_score": float(len(predictions))}
 
     def get_metadata(self):
+        """Declare a dependency-free metric requiring multiple ordered reference sources."""
         return MetricMetadata(
             name="ordered_source",
             category=MetricCategory.DEPENDENT,
@@ -47,6 +54,7 @@ class OrderedSourceMetric(BaseMetric):
 
 
 def _source_mappings():
+    """Build two-source prediction/reference maps sharing two mixture keys and fixture audio."""
     sample_files = list(find_files("test/test_samples/test2").values())
     sample_file = sample_files[0]
     keys = ["mixture-a", "mixture-b"]
@@ -55,6 +63,7 @@ def _source_mappings():
 
 
 def test_multi_source_parser_accepts_ordered_scp_lists():
+    """Preserve the order of predicted and reference SCP arguments in CLI parsing."""
     args = get_parser().parse_args(
         [
             "--pred_sources",
@@ -71,6 +80,7 @@ def test_multi_source_parser_accepts_ordered_scp_lists():
 
 
 def test_multi_source_rejects_only_metrics_that_require_text():
+    """Identify text requirements without rejecting audio-only multi-source metrics."""
     metadata = OrderedSourceMetric().get_metadata()
     score_config = [{"name": "ordered_source"}]
     registry = MetricRegistry()
@@ -88,6 +98,7 @@ def test_multi_source_rejects_only_metrics_that_require_text():
 def test_multi_source_cli_rejects_text_metric_before_generic_validation(
     monkeypatch, tmp_path, capsys
 ):
+    """Reject unsupported text inputs before dependency checks or model setup."""
     registry = MetricRegistry()
     registry.register(
         OrderedSourceMetric,
@@ -100,6 +111,7 @@ def test_multi_source_cli_rejects_text_metric_before_generic_validation(
     )
 
     def unexpected_validation(*args, **kwargs):
+        """Fail if generic validation runs before the multi-source text guard."""
         pytest.fail("generic validation ran before multi-source text validation")
 
     monkeypatch.setattr(
@@ -134,6 +146,7 @@ def test_multi_source_cli_rejects_text_metric_before_generic_validation(
 
 
 def test_multi_source_pipeline_preserves_order_and_writes_jsonl(tmp_path):
+    """Verify paired-source metadata and JSONL output using the real scoring pipeline."""
     registry = MetricRegistry()
     metadata = OrderedSourceMetric().get_metadata()
     registry.register(OrderedSourceMetric, metadata)
@@ -167,6 +180,7 @@ def test_multi_source_pipeline_preserves_order_and_writes_jsonl(tmp_path):
 
 
 def test_multi_source_pipeline_rejects_key_mismatch():
+    """Reject source mappings that do not contain the same mixture keys."""
     registry = MetricRegistry()
     metadata = OrderedSourceMetric().get_metadata()
     registry.register(OrderedSourceMetric, metadata)

--- a/test/test_pipeline/test_scorer_entrypoints.py
+++ b/test/test_pipeline/test_scorer_entrypoints.py
@@ -21,11 +21,15 @@ from versa.definition import (
 
 
 class UtteranceMetric(BaseMetric):
+    """Record reference/text routing and return a fixed utterance score."""
+
     def _setup(self):
+        """Retain I/O and cache options to test configuration forwarding."""
         self.io = self.config.get("io")
         self.cache_dir = self.config.get("cache_dir")
 
     def get_metadata(self):
+        """Expose a dependency-free utterance metric for real scorer orchestration."""
         return MetricMetadata(
             "test_utterance",
             MetricCategory.INDEPENDENT,
@@ -39,12 +43,16 @@ class UtteranceMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Record reference presence and transcript metadata, returning a fixed score."""
         self.calls["utterance"].append((references is not None, metadata["text"]))
         return {"test_score": 0.5}
 
 
 class CorpusMetric(UtteranceMetric):
+    """Record corpus paths, configuration, and metadata without model inference."""
+
     def get_metadata(self):
+        """Declare a distributional metric to exercise corpus dispatch."""
         return MetricMetadata(
             "test_corpus",
             MetricCategory.DISTRIBUTIONAL,
@@ -58,12 +66,17 @@ class CorpusMetric(UtteranceMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Record the corpus invocation and return a fixed corpus score."""
         self.calls["corpus"].append((predictions, references, self.config, metadata))
         return {"corpus_score": 0.25}
 
 
 @pytest.fixture
 def scoring_case(tmp_path, monkeypatch):
+    """Build tiny WAV inputs, fake metrics, CLI arguments, and cleanup call tracking.
+
+    Patch environment variables through monkeypatch so cache changes are
+    restored after each test; all generated inputs live under tmp_path."""
     for key in (
         "VERSA_CACHE_DIR",
         "VERSA_HF_CACHE_DIR",
@@ -88,6 +101,7 @@ def scoring_case(tmp_path, monkeypatch):
     original_close = scorer_shared.ScoreProcessor.close
 
     def close(processor):
+        """Close the real processor and record whether its output handle was released."""
         original_close(processor)
         calls["closed"].append(
             processor.file_handle is None or processor.file_handle.closed
@@ -132,6 +146,7 @@ def scoring_case(tmp_path, monkeypatch):
 def test_entrypoint_outputs_inputs_and_resume(
     scoring_case, monkeypatch, mode, no_match
 ):
+    """Verify scoring modes preserve routing, chunk keys, outputs, resume, and cleanup."""
     root, argv, calls = scoring_case
     entrypoint = scorer_chunk if mode in ("chunk_cli", "chunks") else scorer
     if mode == "metric":
@@ -189,6 +204,7 @@ def test_entrypoint_outputs_inputs_and_resume(
 
 @pytest.mark.parametrize("entrypoint", [scorer, scorer_chunk])
 def test_explicit_corpus_config_wins(scoring_case, monkeypatch, entrypoint):
+    """Ensure explicit corpus I/O and cache settings override entrypoint defaults."""
     root, argv, calls = scoring_case
     (root / "config.yaml").write_text(
         yaml.safe_dump(
@@ -206,6 +222,7 @@ def test_explicit_corpus_config_wins(scoring_case, monkeypatch, entrypoint):
     "entrypoint,error", [(scorer, SystemExit), (scorer_chunk, SystemExit)]
 )
 def test_empty_config_contract(scoring_case, monkeypatch, entrypoint, error):
+    """Reject an empty score configuration with CLI exit status two."""
     root, argv, _ = scoring_case
     (root / "config.yaml").write_text("[]\n")
     monkeypatch.setattr(sys, "argv", argv)
@@ -215,6 +232,7 @@ def test_empty_config_contract(scoring_case, monkeypatch, entrypoint, error):
 
 
 def test_cuda_validation(scoring_case, monkeypatch):
+    """Reject GPU execution when CUDA is unavailable."""
     _, argv, _ = scoring_case
     monkeypatch.setattr(sys, "argv", argv + ["--use_gpu"])
     monkeypatch.setattr(scoring.torch.cuda, "is_available", lambda: False)
@@ -223,6 +241,7 @@ def test_cuda_validation(scoring_case, monkeypatch):
 
 
 def test_report_from_shared_scoring(scoring_case, monkeypatch):
+    """Verify the CLI writes a report containing scores from shared orchestration."""
     root, argv, _ = scoring_case
     report = root / "report.md"
     monkeypatch.setattr(sys, "argv", argv + ["--report", str(report)])
@@ -231,14 +250,17 @@ def test_report_from_shared_scoring(scoring_case, monkeypatch):
 
 
 def test_worker_count_reaches_scorer(scoring_case, monkeypatch):
+    """Verify the requested CPU worker count reaches utterance scoring."""
     _, argv, _ = scoring_case
     original = scoring.run_scoring
     workers = []
 
     def run(args, instance, *positional, **keywords):
+        """Wrap shared orchestration to observe the worker argument without spawning workers."""
         score_utterances = instance.score_utterances
 
         def score(*positional, **keywords):
+            """Record the requested worker count and score serially for this routing test."""
             workers.append(keywords.pop("num_workers"))
             return score_utterances(*positional, **keywords)
 
@@ -255,6 +277,7 @@ def test_worker_count_reaches_scorer(scoring_case, monkeypatch):
 def test_invalid_config_rejected_before_audio_loading(
     scoring_case, monkeypatch, entrypoint
 ):
+    """Reject unknown metrics before attempting to load missing audio files."""
     root, argv, calls = scoring_case
     (root / "config.yaml").write_text("- name: unknown_metric\n")
     (root / "pred/utt.wav").unlink()
@@ -267,6 +290,7 @@ def test_invalid_config_rejected_before_audio_loading(
 
 @pytest.mark.parametrize("entrypoint", [scorer, scorer_chunk])
 def test_literal_none_reference_without_text(scoring_case, monkeypatch, entrypoint):
+    """Interpret the literal None reference argument as absent in both entrypoints."""
     _, argv, calls = scoring_case
     argv[argv.index("--gt") + 1] = "None"
     text_index = argv.index("--text")

--- a/test/test_pipeline/test_scorer_entrypoints.py
+++ b/test/test_pipeline/test_scorer_entrypoints.py
@@ -179,7 +179,7 @@ def test_entrypoint_outputs_inputs_and_resume(
     pred, gt, config, metadata = calls["corpus"][0]
     if mode == "chunks":
         assert pred == str(output) + ".chunks/pred"
-        assert gt is None
+        assert gt == (None if no_match else str(output) + ".chunks/gt")
     elif mode == "chunk_cli":
         assert pred == str(root / "pred")
         assert gt == (None if no_match else str(root / "gt"))
@@ -299,3 +299,38 @@ def test_literal_none_reference_without_text(scoring_case, monkeypatch, entrypoi
     entrypoint.main()
     assert calls["utterance"] == [(False, None)]
     assert calls["corpus"][0][1] is None
+
+
+@pytest.mark.parametrize("reference_keys", [[], ["different.wav"]])
+def test_chunking_rejects_missing_reference_keys(scoring_case, reference_keys):
+    """Validate pairing before any chunk files are created, including equal counts."""
+    root, argv, calls = scoring_case
+    args = scorer_chunk.get_parser().parse_args(argv[1:] + ["--enable_chunking"])
+    with pytest.raises(ValueError, match="Ground truth is missing.*utt.wav"):
+        scorer_chunk._maybe_chunk_filelists(
+            args,
+            {"utt.wav": str(root / "pred/utt.wav")},
+            dict.fromkeys(reference_keys, str(root / "gt/utt.wav")),
+            None,
+        )
+    assert not (root / "scores.jsonl.chunks").exists()
+    assert not calls["corpus"] and not calls["utterance"]
+
+
+def test_chunked_corpus_uses_directories_for_scp_inputs(scoring_case, monkeypatch):
+    """Route paired chunk directories to corpus metrics even when input uses SCP."""
+    root, argv, calls = scoring_case
+    for folder in ("pred", "gt"):
+        scp = root / f"{folder}.scp"
+        scp.write_text(f"utt.wav {root / folder / 'utt.wav'}\n")
+        argv[argv.index(f"--{folder}") + 1] = str(scp)
+    argv[argv.index("--io") + 1] = "soundfile"
+    monkeypatch.setattr(sys, "argv", argv + ["--enable_chunking"])
+    scorer_chunk.main()
+    pred, gt, config, _ = calls["corpus"][0]
+    assert config["io"] == "dir"
+    assert Path(pred).is_dir() and Path(gt).is_dir()
+    assert {p.name for p in Path(pred).glob("*.wav")} == {
+        p.name for p in Path(gt).glob("*.wav")
+    }
+    assert all(paired for paired, _ in calls["utterance"])

--- a/test/test_qwen_postprocess.py
+++ b/test/test_qwen_postprocess.py
@@ -21,6 +21,7 @@ from scripts.postprocess.check_llm_result_match import (
     ],
 )
 def test_standardizer_rules_without_models(monkeypatch, module_name, class_name):
+    """Verify shared normalization and historical fallbacks with LLM loading disabled."""
     module = importlib.import_module("scripts.postprocess." + module_name)
     monkeypatch.setattr(module, "AutoTokenizer", None)
     monkeypatch.setattr(module, "AutoModelForCausalLM", None)
@@ -72,6 +73,7 @@ def test_standardizer_rules_without_models(monkeypatch, module_name, class_name)
 
 
 def test_filter_retains_historical_subset():
+    """Keep overlapping-speech normalization out of the historical filter schema."""
     assert set(FILTER_FORMATS) == set(rules.EXPECTED_FORMATS) - {
         "qwen_overlapping_speech"
     }
@@ -85,6 +87,7 @@ def test_filter_retains_historical_subset():
     ],
 )
 def test_direct_script_import(script, tmp_path):
+    """Verify each standardizer CLI imports from outside the repository directory."""
     path = Path(__file__).resolve().parents[1] / "scripts/postprocess" / script
     result = subprocess.run(
         [sys.executable, str(path), "--help"],

--- a/versa/__init__.py
+++ b/versa/__init__.py
@@ -21,6 +21,7 @@ os.environ.setdefault(
 
 
 def __getattr__(name):
+    """Lazily import and cache a public metric symbol, raising for unknown names."""
     if name in metric_symbol_names():
         symbol = load_metric_symbol(name)
         globals()[name] = symbol
@@ -29,4 +30,5 @@ def __getattr__(name):
 
 
 def __dir__():
+    """List loaded attributes together with public metric symbols available lazily."""
     return sorted(set(globals()) | set(metric_symbol_names()))

--- a/versa/bin/__init__.py
+++ b/versa/bin/__init__.py
@@ -1,0 +1,1 @@
+"""Command-line entrypoints for scoring, aggregation, and report generation."""

--- a/versa/bin/scorer.py
+++ b/versa/bin/scorer.py
@@ -222,6 +222,11 @@ def _text_required_multi_source_metrics(score_config, registry):
 
 
 def main():
+    """Parse discovery or scoring options, validate inputs, and run the selected mode.
+
+    Scoring may initialize models and write or append results. Ordered
+    multi-source mode requires paired SCP lists and one utterance worker.
+    When requested, write a report from the resulting utterance records."""
     parser = get_parser()
     args = parser.parse_args()
 
@@ -408,6 +413,10 @@ def _write_report(
     outlier_limit,
     registry,
 ):
+    """Create the parent directory and overwrite a report from utterance records.
+
+    Infer HTML, CSV, or Markdown from the extension in auto mode; unknown
+    extensions default to HTML."""
     from pathlib import Path
 
     from versa.reporting import (

--- a/versa/bin/scorer_chunk.py
+++ b/versa/bin/scorer_chunk.py
@@ -224,10 +224,18 @@ def _maybe_chunk_filelists(
 ) -> tuple[dict, dict | None, dict | None, Path | None]:
     """
     If chunking is enabled, create on-disk chunked wavs and return updated mappings.
-    Also replicates text_info per chunk key.
+    Also replicates text_info per chunk key. Reject missing reference keys before
+    writing any chunks.
     """
     if not args.enable_chunking:
         return gen_files, gt_files, text_info, None
+
+    if gt_files is not None:
+        missing_gt = sorted(set(gen_files) - set(gt_files))
+        if missing_gt:
+            raise ValueError(
+                f"Ground truth is missing for generated keys: {missing_gt}"
+            )
 
     chunk_sec = float(args.chunk_duration)
     hop_sec = float(args.hop_duration) if args.hop_duration is not None else chunk_sec
@@ -251,7 +259,7 @@ def _maybe_chunk_filelists(
     text_chunks_all: dict | None = {} if text_info is not None else None
 
     for key, pred_path in gen_files.items():
-        gt_path = gt_files.get(key) if gt_files is not None else None
+        gt_path = gt_files[key] if gt_files is not None else None
         try:
             g_map, r_map = _chunk_pair_to_tmp(
                 key,
@@ -271,9 +279,6 @@ def _maybe_chunk_filelists(
         gen_chunks_all.update(g_map)
         if gt_chunks_all is not None and r_map is not None:
             gt_chunks_all.update(r_map)
-        elif gt_chunks_all is not None and r_map is None:
-            # keep structure consistent
-            gt_chunks_all = None
 
         # Duplicate text per chunk if provided
         if text_chunks_all is not None and text_info is not None and key in text_info:
@@ -326,7 +331,7 @@ def main():
     if args.enable_chunking and chunk_tmp_dir is not None:
         pred_for_corpus = str(chunk_tmp_dir / "pred")
         logging.info(f"Corpus scoring over chunk directory: {pred_for_corpus}")
-        gt_for_corpus = None
+        gt_for_corpus = str(chunk_tmp_dir / "gt") if gt_files is not None else None
 
     has_metrics, _ = run_scoring(
         args,
@@ -337,8 +342,8 @@ def main():
         text_info,
         corpus_inputs=(pred_for_corpus, gt_for_corpus),
         parser=parser,
-        corpus_defaults={"io": args.io},
-        corpus_use_gt=args.gt is not None,
+        corpus_defaults={"io": "dir" if args.enable_chunking else args.io},
+        corpus_use_gt=gt_for_corpus is not None,
     )
     assert has_metrics, "no scoring function is provided"
 

--- a/versa/bin/scorer_chunk.py
+++ b/versa/bin/scorer_chunk.py
@@ -284,6 +284,10 @@ def _maybe_chunk_filelists(
 
 
 def main():
+    """Validate CLI inputs, optionally materialize audio chunks, and run scoring.
+
+    Chunk mode uses the generated prediction directory for corpus metrics;
+    chunk files remain available after scoring."""
     parser = get_parser()
     args = parser.parse_args()
 

--- a/versa/bin/scoring.py
+++ b/versa/bin/scoring.py
@@ -16,6 +16,9 @@ from versa.scorer_shared import (
 
 def configure_runtime(args):
     # In case of using `local` backend, all GPU will be visible to all process.
+    """Configure logging and select a CUDA device by rank when GPU use is requested.
+
+    Raise RuntimeError when GPU execution is requested without a CUDA device."""
     if args.use_gpu:
         if not torch.cuda.is_available() or torch.cuda.device_count() == 0:
             raise RuntimeError("--use_gpu was set, but no CUDA device is available")
@@ -37,6 +40,11 @@ def configure_runtime(args):
 
 
 def load_inputs(args, *, check_reference_count=True):
+    """Load prediction, reference, and transcript mappings from CLI arguments.
+
+    Normalize the literal ground-truth value ``None`` on args and omit paired
+    references in no-match mode. Reject empty predictions and, when enabled,
+    a reference collection smaller than the prediction collection."""
     gen_files = audio_loader_setup(args.pred, args.io)
 
     # find reference file

--- a/versa/bin/visualize.py
+++ b/versa/bin/visualize.py
@@ -17,6 +17,7 @@ from versa.reporting import (
 
 
 def get_parser() -> argparse.ArgumentParser:
+    """Build CLI options for reading results and exporting summary reports."""
     parser = argparse.ArgumentParser(
         description="Create summary tables and visual reports from VERSA results.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -61,6 +62,7 @@ def get_parser() -> argparse.ArgumentParser:
 
 
 def main() -> None:
+    """Read CLI result files and write the requested reports, creating parent folders."""
     parser = get_parser()
     args = parser.parse_args()
 

--- a/versa/config_validation.py
+++ b/versa/config_validation.py
@@ -53,6 +53,7 @@ class ScoreConfigValidationError:
     message: str
 
     def format(self) -> str:
+        """Format the error with its configuration index and metric name, if known."""
         location = "score_config"
         if self.index is not None:
             location += f"[{self.index}]"
@@ -65,6 +66,7 @@ class ScoreConfigValidationException(ValueError):
     """Raised when a score configuration cannot be used safely."""
 
     def __init__(self, errors: Iterable[ScoreConfigValidationError]):
+        """Retain all validation issues and combine their messages into one error."""
         self.errors = list(errors)
         message = "Invalid score configuration:\n" + "\n".join(
             f"- {error.format()}" for error in self.errors
@@ -204,6 +206,7 @@ def validate_score_config(
 
 
 def _unknown_metric_message(registry: MetricRegistry, metric_name: str) -> str:
+    """Describe an unknown name, appending up to five substring matches."""
     message = f"unknown metric name '{metric_name}'"
     suggestions = _suggest_metric_names(registry, metric_name)
     if suggestions:
@@ -212,12 +215,14 @@ def _unknown_metric_message(registry: MetricRegistry, metric_name: str) -> str:
 
 
 def _suggest_metric_names(registry: MetricRegistry, metric_name: str) -> List[str]:
+    """Return up to five sorted names or aliases containing the query, ignoring case."""
     query = metric_name.lower()
     names = set(registry.list_metrics()) | set(registry.list_aliases())
     return sorted(name for name in names if query in name.lower())[:5]
 
 
 def _requires_gpu_flag(metric_name: str) -> bool:
+    """Return whether a metric is configured to require explicit GPU opt-in."""
     return metric_name in _GPU_REQUIRED_METRICS or metric_name.startswith(
         _GPU_REQUIRED_PREFIXES
     )
@@ -225,11 +230,16 @@ def _requires_gpu_flag(metric_name: str) -> bool:
 
 @lru_cache(maxsize=None)
 def _dependency_available(dependency: str) -> bool:
+    """Cache whether Python can locate the requested dependency module."""
     return importlib.util.find_spec(dependency) is not None
 
 
 @lru_cache(maxsize=None)
 def _allowed_config_keys(metric_class: type) -> Optional[frozenset]:
+    """Collect literal config keys from the class hierarchy without running setup.
+
+    Include the common name/device keys. Return None when no class source can
+    be parsed, so callers can avoid rejecting keys on incomplete evidence."""
     keys: Set[str] = set(_BASE_CONFIG_KEYS)
     found_source = False
 
@@ -256,6 +266,7 @@ def _allowed_config_keys(metric_class: type) -> Optional[frozenset]:
 
 
 def _self_config_get_key(node: ast.AST) -> Optional[str]:
+    """Extract a literal string key from a ``self.config.get(...)`` AST call."""
     if not isinstance(node, ast.Call):
         return None
     if not isinstance(node.func, ast.Attribute) or node.func.attr != "get":
@@ -271,6 +282,7 @@ def _self_config_get_key(node: ast.AST) -> Optional[str]:
 
 
 def _self_config_subscript_key(node: ast.AST) -> Optional[str]:
+    """Extract a literal string key from a ``self.config[...]`` AST expression."""
     if not isinstance(node, ast.Subscript) or not _is_self_config(node.value):
         return None
     slice_node = node.slice
@@ -280,6 +292,7 @@ def _self_config_subscript_key(node: ast.AST) -> Optional[str]:
 
 
 def _is_self_config(node: ast.AST) -> bool:
+    """Return whether an AST node refers exactly to the ``self.config`` attribute."""
     return (
         isinstance(node, ast.Attribute)
         and node.attr == "config"

--- a/versa/corpus_metrics/__init__.py
+++ b/versa/corpus_metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Corpus-level metric implementations."""

--- a/versa/corpus_metrics/clap_score.py
+++ b/versa/corpus_metrics/clap_score.py
@@ -3,6 +3,7 @@
 # Copyright 2025 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""CLAP audio-text similarity over keyed audio collections."""
 import logging
 import os
 
@@ -29,6 +30,10 @@ def clap_score_setup(
     cache_embeddings=False,
     io="kaldi",
 ):
+    """Load the CLAP backend and retain audio I/O and embedding-cache settings.
+
+    The backend may download weights. Embedding caching is opt-in and is used
+    during scoring; a missing backend raises ModuleNotFoundError."""
     if CLAPScore is None:
         raise ModuleNotFoundError(
             "frechet_audio_distance is not installed. "
@@ -53,12 +58,16 @@ def clap_score_setup(
 
 
 def _load_audio_entry(audio_info):
+    """Read a Kaldi sample-rate/waveform tuple or soundfile path as ``(rate, audio)``."""
     if isinstance(audio_info, tuple):
         return load_audio(audio_info, "kaldi")
     return load_audio(audio_info, "soundfile")
 
 
 def _load_audio_list(audio_files, target_sample_rate):
+    """Load sorted keyed audio as float32 mono arrays at target_sample_rate Hz.
+
+    Select the first channel and scale int16 data through wav_normalize."""
     audio_data = []
     for key in sorted(audio_files):
         sample_rate, wav = _load_audio_entry(audio_files[key])
@@ -78,6 +87,13 @@ def clap_score_scoring(
     key_info="clap_score",
     batch_size=10,
 ):
+    """Return mean paired audio/text similarity under key_info.
+
+    Accept a keyed audio mapping or input path interpreted with clap_info io.
+    text_info must contain every audio key. Sort both modalities by key and
+    resample audio to the CLAP rate. When enabled, read/write fixed embedding
+    cache filenames; callers must use a fresh cache for different collections.
+    Missing text, empty embeddings, or mismatched shapes raise ValueError."""
     if text_info is None:
         raise ValueError("CLAP score requires text references via --text.")
 
@@ -142,6 +158,7 @@ class ClapScoreMetric(BaseMetric):
     """Corpus-level CLAP score for paired text/audio alignment."""
 
     def _setup(self):
+        """Load the selected CLAP model and retain batch, I/O, and embedding-cache options."""
         self.io = self.config.get("io", "kaldi")
         self.batch_size = self.config.get("batch_size", 10)
         self.clap_info = clap_score_setup(
@@ -156,6 +173,13 @@ class ClapScoreMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return a scalar mean CLAP score for a keyed collection or corpus input path.
+
+        Require ``metadata["text_info"]`` keyed like the audio. File rates or
+        Kaldi tuples supply sample rates; audio is reduced to its first channel
+        and resampled. References are unused. Embeddings may be cached on disk.
+        Return backend similarity without clipping; invalid alignment raises
+        ValueError as described by ``clap_score_scoring``."""
         metadata = metadata or {}
         text_info = metadata.get("text_info")
         if text_info is None:
@@ -170,10 +194,12 @@ class ClapScoreMetric(BaseMetric):
         return scores["clap_score"]
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _clap_score_metadata()
 
 
 def _clap_score_metadata():
+    """Return registry metadata describing clap score inputs and dependencies."""
     return MetricMetadata(
         name="clap_score",
         category=MetricCategory.DISTRIBUTIONAL,
@@ -190,6 +216,7 @@ def _clap_score_metadata():
 
 
 def register_clap_score_metric(registry):
+    """Register corpus CLAP similarity and its aliases in the supplied registry."""
     registry.register(
         ClapScoreMetric,
         _clap_score_metadata(),

--- a/versa/corpus_metrics/espnet_wer.py
+++ b/versa/corpus_metrics/espnet_wer.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""ESPnet speech recognition and corpus transcription error rates."""
 import importlib.util
 import logging
 
@@ -16,6 +17,7 @@ from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricT
 
 
 def _ensure_torchaudio_legacy_backend_api():
+    """Supply the removed no-op backend setter needed by legacy ESPnet imports."""
     try:
         import torchaudio
     except ImportError:
@@ -45,6 +47,7 @@ def espnet_wer_setup(
     use_gpu=True,
     cache_dir=None,
 ):
+    """Load ESPnet ASR and its text cleaner on CPU/CUDA, optionally caching model-zoo assets."""
     if model_tag == "default":
         model_tag = (
             "espnet/"
@@ -192,6 +195,7 @@ class EspnetWerMetric(BaseMetric):
     """ESPnet ASR-based WER/CER edit counts."""
 
     def _setup(self):
+        """Load the configured ESPnet recognizer and retain decoding/cache settings."""
         self.model_tag = self.config.get("model_tag", "default")
         self.beam_size = self.config.get("beam_size", 5)
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
@@ -206,6 +210,14 @@ class EspnetWerMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ESPnet word/character edit counts for a mono utterance.
+
+        Require predictions and reference text in metadata text or a string
+        references argument. Use metadata sample_rate in Hz (default 16000),
+        resampling to 16 kHz for ASR without channel mixing. Return
+        espnet_hyp_text, ref_text, and espnet_wer_*/espnet_cer_* counts
+        for delete, insert, replace, and equal; these are counts, not error rates.
+        Missing audio or text raises ValueError; inference failures propagate."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -225,10 +237,12 @@ class EspnetWerMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _espnet_wer_metadata()
 
 
 def _espnet_wer_metadata():
+    """Return registry metadata describing espnet wer inputs and dependencies."""
     return MetricMetadata(
         name="espnet_wer",
         category=MetricCategory.NON_MATCH,

--- a/versa/corpus_metrics/fad.py
+++ b/versa/corpus_metrics/fad.py
@@ -70,7 +70,8 @@ class FadMetric(BaseMetric):
         """Compare prediction and reference audio collections through cached embeddings.
 
         Inputs are keyed mappings or paths interpreted by the configured io mode.
-        Use references, then metadata baseline_files, then the configured baseline.
+        Use the first non-None source: references, metadata baseline_files, or the
+        configured baseline. Reject empty resolved collections.
         Sample rates and channel processing are delegated to FADTK audio loading.
         Cache embeddings in baseline/eval subdirectories under cache_dir.
 
@@ -83,12 +84,20 @@ class FadMetric(BaseMetric):
             raise ValueError("FAD requires prediction audio files")
 
         metadata = metadata or {}
-        baseline = references or metadata.get("baseline_files") or self.baseline
+        baseline = references
+        if baseline is None:
+            baseline = metadata.get("baseline_files")
+        if baseline is None:
+            baseline = self.baseline
         if baseline is None:
             raise ValueError("FAD requires reference or baseline audio files")
 
         baseline_files = _load_audio_collection(baseline, self.io)
         eval_files = _load_audio_collection(predictions, self.io)
+        if not baseline_files or not eval_files:
+            raise ValueError(
+                "FAD requires non-empty prediction and baseline collections"
+            )
 
         logging.info("[FAD] caching baseline embeddings...")
         for key in tqdm(baseline_files.keys()):

--- a/versa/corpus_metrics/fad.py
+++ b/versa/corpus_metrics/fad.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Frechet audio distance over prediction and reference collections."""
 import logging
 
 from tqdm import tqdm
@@ -22,12 +23,14 @@ except ImportError:
 
 
 def _load_audio_collection(audio, io):
+    """Use an existing keyed audio mapping or load one with the selected I/O mode."""
     if isinstance(audio, dict):
         return audio
     return audio_loader_setup(audio, io)
 
 
 def _fad_metadata():
+    """Return registry metadata describing fad inputs and dependencies."""
     return MetricMetadata(
         name="fad",
         category=MetricCategory.DISTRIBUTIONAL,
@@ -47,6 +50,7 @@ class FadMetric(BaseMetric):
     """Frechet Audio Distance over prediction and reference collections."""
 
     def _setup(self):
+        """Require FADTK, load the configured embedding model, and retain cache/I/O settings."""
         if get_model is None or FrechetAudioDistance is None:
             raise ModuleNotFoundError(
                 "FADTK is not installed. Please install it following `tools/install_fadtk.sh`"
@@ -63,6 +67,18 @@ class FadMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Compare prediction and reference audio collections through cached embeddings.
+
+        Inputs are keyed mappings or paths interpreted by the configured io mode.
+        Use references, then metadata baseline_files, then the configured baseline.
+        Sample rates and channel processing are delegated to FADTK audio loading.
+        Cache embeddings in baseline/eval subdirectories under cache_dir.
+
+        Return ``fad_overall`` and, for extrapolated scoring, ``fad_r2``.
+        Use extrapolation when configured or when collection sizes differ.
+        Distance values retain backend scaling without clipping. Missing prediction
+        or baseline inputs raise ValueError; backend loading/statistics errors propagate.
+        """
         if predictions is None:
             raise ValueError("FAD requires prediction audio files")
 
@@ -97,6 +113,7 @@ class FadMetric(BaseMetric):
         }
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _fad_metadata()
 
 

--- a/versa/corpus_metrics/fwhisper_wer.py
+++ b/versa/corpus_metrics/fwhisper_wer.py
@@ -3,6 +3,7 @@
 # Copyright 2025 Haoran Wang
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Faster-Whisper corpus transcription and error-rate evaluation."""
 import logging
 
 import numpy as np
@@ -39,6 +40,9 @@ def fwhisper_wer_setup(
     use_gpu=True,
     cache_dir="versa_cache/faster_whisper",
 ):
+    """Load Faster-Whisper and a text cleaner, enabling batched inference when batch_size > 1.
+
+    Weights may be downloaded into cache_dir using the requested compute_type."""
     if model_tag == "default":
         model_tag = "large-v3"
     device = "cuda" if use_gpu else "cpu"
@@ -171,6 +175,7 @@ class FasterWhisperWerMetric(BaseMetric):
     """Faster-Whisper ASR-based WER/CER edit counts."""
 
     def _setup(self):
+        """Load the configured Faster-Whisper recognizer and retain decoding/cache settings."""
         self.model_tag = self.config.get("model_tag", "default")
         self.beam_size = self.config.get("beam_size", 5)
         self.batch_size = self.config.get("batch_size", 1)
@@ -189,6 +194,15 @@ class FasterWhisperWerMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return Faster-Whisper word/character edit counts for a mono utterance.
+
+        Require predictions and reference text in metadata text or a string
+        references argument. Use metadata sample_rate in Hz (default 16000),
+        resampling to 16 kHz for ASR without channel mixing. Return
+        fwhisper_hyp_text, ref_text, and fwhisper_wer_*/fwhisper_cer_* counts
+        for delete, insert, replace, and equal; these are counts, not error rates.
+        Missing audio or text raises ValueError; inference failures propagate.
+        Reuse fwhisper_hyp_text from metadata or general_cache when available."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -214,10 +228,12 @@ class FasterWhisperWerMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _fwhisper_wer_metadata()
 
 
 def _fwhisper_wer_metadata():
+    """Return registry metadata describing fwhisper wer inputs and dependencies."""
     return MetricMetadata(
         name="fwhisper_wer",
         category=MetricCategory.NON_MATCH,

--- a/versa/corpus_metrics/hubert_wer.py
+++ b/versa/corpus_metrics/hubert_wer.py
@@ -3,6 +3,7 @@
 # Copyright 2025 Haoran Wang
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""HuBERT CTC speech recognition and corpus transcription error rates."""
 import logging
 
 import numpy as np
@@ -33,6 +34,9 @@ def hubert_wer_setup(
     use_gpu=True,
     cache_dir="versa_cache/huggingface",
 ):
+    """Load the HuBERT CTC model, processor, and text cleaner on CPU or CUDA.
+
+    Hugging Face model and processor assets may be downloaded into cache_dir."""
     if model_tag == "default":
         model_tag = "facebook/hubert-large-ls960-ft"
     device = "cuda" if use_gpu else "cpu"
@@ -144,6 +148,7 @@ class HubertWerMetric(BaseMetric):
     """HuBERT CTC ASR-based WER/CER edit counts."""
 
     def _setup(self):
+        """Load the configured HuBERT recognizer and retain decoding/cache settings."""
         self.model_tag = self.config.get("model_tag", "default")
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
         self.use_gpu = self.config.get("use_gpu", True)
@@ -156,6 +161,15 @@ class HubertWerMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return HuBERT word/character edit counts for a mono utterance.
+
+        Require predictions and reference text in metadata text or a string
+        references argument. Use metadata sample_rate in Hz (default 16000),
+        resampling to 16 kHz for ASR without channel mixing. Return
+        hubert_hyp_text, ref_text, and hubert_wer_*/hubert_cer_* counts
+        for delete, insert, replace, and equal; these are counts, not error rates.
+        Missing audio or text raises ValueError; inference failures propagate.
+        Reuse hubert_hyp_text from metadata or general_cache when available."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -181,10 +195,12 @@ class HubertWerMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _hubert_wer_metadata()
 
 
 def _hubert_wer_metadata():
+    """Return registry metadata describing hubert wer inputs and dependencies."""
     return MetricMetadata(
         name="hubert_wer",
         category=MetricCategory.NON_MATCH,

--- a/versa/corpus_metrics/individual_fad.py
+++ b/versa/corpus_metrics/individual_fad.py
@@ -85,7 +85,8 @@ class IndividualFadMetric(BaseMetric):
         """Compare prediction and reference audio collections through cached embeddings.
 
         Inputs are keyed mappings or paths interpreted by the configured io mode.
-        Use references, then metadata baseline_files, then the configured baseline.
+        Use the first non-None source: references, metadata baseline_files, or the
+        configured baseline. Reject empty resolved collections.
         Sample rates and channel processing are delegated to FADTK audio loading.
         Cache embeddings in baseline/eval subdirectories under cache_dir.
 
@@ -98,7 +99,11 @@ class IndividualFadMetric(BaseMetric):
             raise ValueError("Individual FAD requires prediction audio files")
 
         metadata = metadata or {}
-        baseline = references or metadata.get("baseline_files") or self.baseline
+        baseline = references
+        if baseline is None:
+            baseline = metadata.get("baseline_files")
+        if baseline is None:
+            baseline = self.baseline
         if baseline is None:
             raise ValueError(
                 "Individual FAD requires reference or baseline audio files"
@@ -106,6 +111,10 @@ class IndividualFadMetric(BaseMetric):
 
         baseline_files = _load_audio_collection(baseline, self.io)
         eval_files = _load_audio_collection(predictions, self.io)
+        if not baseline_files or not eval_files:
+            raise ValueError(
+                "Individual FAD requires non-empty prediction and baseline collections"
+            )
 
         baseline_cache = Path(self.cache_dir) / "baseline"
         eval_cache = Path(self.cache_dir) / "eval"

--- a/versa/corpus_metrics/individual_fad.py
+++ b/versa/corpus_metrics/individual_fad.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Per-file Frechet audio distances against a reference collection."""
 import logging
 from pathlib import Path
 
@@ -30,12 +31,14 @@ except ImportError:
 
 
 def _load_audio_collection(audio, io):
+    """Use an existing keyed audio mapping or load one with the selected I/O mode."""
     if isinstance(audio, dict):
         return audio
     return audio_loader_setup(audio, io)
 
 
 def _individual_fad_metadata():
+    """Return registry metadata describing individual fad inputs and dependencies."""
     return MetricMetadata(
         name="individual_fad",
         category=MetricCategory.DISTRIBUTIONAL,
@@ -58,6 +61,7 @@ class IndividualFadMetric(BaseMetric):
     """Per-file Frechet Audio Distance against a reference collection."""
 
     def _setup(self):
+        """Require FADTK, load the configured embedding model, and retain cache/I/O settings."""
         if (
             get_model is None
             or FrechetAudioDistance is None
@@ -78,6 +82,18 @@ class IndividualFadMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Compare prediction and reference audio collections through cached embeddings.
+
+        Inputs are keyed mappings or paths interpreted by the configured io mode.
+        Use references, then metadata baseline_files, then the configured baseline.
+        Sample rates and channel processing are delegated to FADTK audio loading.
+        Cache embeddings in baseline/eval subdirectories under cache_dir.
+
+        Return ``individual_fad`` mapping each prediction key to its distance
+        from the pooled reference embedding distribution.
+        Distance values retain backend scaling without clipping. Missing prediction
+        or baseline inputs raise ValueError; backend loading/statistics errors propagate.
+        """
         if predictions is None:
             raise ValueError("Individual FAD requires prediction audio files")
 
@@ -123,6 +139,7 @@ class IndividualFadMetric(BaseMetric):
         return {"individual_fad": scores}
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _individual_fad_metadata()
 
 

--- a/versa/corpus_metrics/kid.py
+++ b/versa/corpus_metrics/kid.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Kernel inception distance between audio embedding collections."""
 import logging
 
 from tqdm import tqdm
@@ -22,12 +23,14 @@ except ImportError:
 
 
 def _load_audio_collection(audio, io):
+    """Use an existing keyed audio mapping or load one with the selected I/O mode."""
     if isinstance(audio, dict):
         return audio
     return audio_loader_setup(audio, io)
 
 
 def _kid_metadata():
+    """Return registry metadata describing kid inputs and dependencies."""
     return MetricMetadata(
         name="kid",
         category=MetricCategory.DISTRIBUTIONAL,
@@ -47,6 +50,7 @@ class KidMetric(BaseMetric):
     """Kernel distance metric over prediction and reference collections."""
 
     def _setup(self):
+        """Require FADTK, load the configured embedding model, and retain cache/I/O settings."""
         if get_model is None or FrechetAudioDistance is None:
             raise ModuleNotFoundError(
                 "FADTK is not installed. Please install it following `tools/install_fadtk.sh`"
@@ -64,6 +68,18 @@ class KidMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Compare prediction and reference audio collections through cached embeddings.
+
+        Inputs are keyed mappings or paths interpreted by the configured io mode.
+        Use references, then metadata baseline_files, then the configured baseline.
+        Sample rates and channel processing are delegated to FADTK audio loading.
+        Cache embeddings in baseline/eval subdirectories under cache_dir.
+
+        Require at least two files in each collection. Return backend KID
+        statistics with ``kid`` prepended to each key.
+        Distance values retain backend scaling without clipping. Missing prediction
+        or baseline inputs raise ValueError; backend loading/statistics errors propagate.
+        """
         if predictions is None:
             raise ValueError("KID requires prediction audio files")
 
@@ -99,6 +115,7 @@ class KidMetric(BaseMetric):
         }
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _kid_metadata()
 
 

--- a/versa/corpus_metrics/kid.py
+++ b/versa/corpus_metrics/kid.py
@@ -71,7 +71,8 @@ class KidMetric(BaseMetric):
         """Compare prediction and reference audio collections through cached embeddings.
 
         Inputs are keyed mappings or paths interpreted by the configured io mode.
-        Use references, then metadata baseline_files, then the configured baseline.
+        Use the first non-None source: references, metadata baseline_files, or the
+        configured baseline. Reject empty resolved collections.
         Sample rates and channel processing are delegated to FADTK audio loading.
         Cache embeddings in baseline/eval subdirectories under cache_dir.
 
@@ -84,7 +85,11 @@ class KidMetric(BaseMetric):
             raise ValueError("KID requires prediction audio files")
 
         metadata = metadata or {}
-        baseline = references or metadata.get("baseline_files") or self.baseline
+        baseline = references
+        if baseline is None:
+            baseline = metadata.get("baseline_files")
+        if baseline is None:
+            baseline = self.baseline
         if baseline is None:
             raise ValueError("KID requires reference or baseline audio files")
 

--- a/versa/corpus_metrics/nemo_wer.py
+++ b/versa/corpus_metrics/nemo_wer.py
@@ -3,6 +3,7 @@
 # Copyright 2025 Haoran Wang
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""NeMo speech recognition and corpus transcription error rates."""
 import logging
 import os
 import tempfile
@@ -38,6 +39,7 @@ def nemo_wer_setup(
     use_gpu=True,
     cache_dir="versa_cache/nemo",
 ):
+    """Set NEMO_CACHE_DIR and load a NeMo transducer with a text cleaner on CPU/CUDA."""
     if model_tag == "default":
         model_tag = "nvidia/stt_en_conformer_transducer_xlarge"
     device = "cuda" if use_gpu else "cpu"
@@ -57,6 +59,7 @@ def nemo_wer_setup(
 
 
 def _extract_nemo_text(transcription):
+    """Extract text from a string, hypothesis object, or first nested transcription."""
     if isinstance(transcription, str):
         return transcription
     if hasattr(transcription, "text"):
@@ -149,6 +152,7 @@ class NemoWerMetric(BaseMetric):
     """NVIDIA NeMo ASR-based WER/CER edit counts."""
 
     def _setup(self):
+        """Load the configured NeMo recognizer and retain decoding/cache settings."""
         self.model_tag = self.config.get("model_tag", "default")
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
         self.use_gpu = self.config.get("use_gpu", True)
@@ -161,6 +165,16 @@ class NemoWerMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return NeMo word/character edit counts for a mono utterance.
+
+        Require predictions and reference text in metadata text or a string
+        references argument. Use metadata sample_rate in Hz (default 16000),
+        resampling to 16 kHz for ASR without channel mixing. Return
+        nemo_hyp_text, ref_text, and nemo_wer_*/nemo_cer_* counts
+        for delete, insert, replace, and equal; these are counts, not error rates.
+        Missing audio or text raises ValueError; inference failures propagate.
+        Reuse nemo_hyp_text from metadata or general_cache when available.
+        Uncached inference writes a temporary WAV and removes it in a finally block."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -186,10 +200,12 @@ class NemoWerMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _nemo_wer_metadata()
 
 
 def _nemo_wer_metadata():
+    """Return registry metadata describing nemo wer inputs and dependencies."""
     return MetricMetadata(
         name="nemo_wer",
         category=MetricCategory.NON_MATCH,

--- a/versa/corpus_metrics/owsm_wer.py
+++ b/versa/corpus_metrics/owsm_wer.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""OWSM speech recognition with corpus error rates and timestamp formatting."""
 import importlib.util
 import logging
 
@@ -32,6 +33,9 @@ def owsm_wer_setup(
     use_gpu=True,
     cache_dir=None,
 ):
+    """Load OWSM for ASR without predicted timestamps and construct its text cleaner.
+
+    Use the requested beam size and device, optionally caching model-zoo assets."""
     if model_tag == "default":
         model_tag = "espnet/owsm_v3.1_ebf"
     device = "cuda" if use_gpu else "cpu"
@@ -76,6 +80,7 @@ def owsm_wer_setup(
 def format_timestamp(
     seconds: float, always_include_hours: bool = False, decimal_marker: str = "."
 ):
+    """Format nonnegative seconds as [HH:]MM:SS.mmm with configurable decimal marker."""
     assert seconds >= 0, "non-negative timestamp expected"
     milliseconds = round(seconds * 1000.0)
 
@@ -244,6 +249,7 @@ class OwsmWerMetric(BaseMetric):
     """OWSM ASR-based WER/CER edit counts."""
 
     def _setup(self):
+        """Load the configured OWSM recognizer and retain decoding/cache settings."""
         self.model_tag = self.config.get("model_tag", "default")
         self.beam_size = self.config.get("beam_size", 5)
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
@@ -258,6 +264,14 @@ class OwsmWerMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return OWSM word/character edit counts for a mono utterance.
+
+        Require predictions and reference text in metadata text or a string
+        references argument. Use metadata sample_rate in Hz (default 16000),
+        resampling to 16 kHz for ASR without channel mixing. Return
+        owsm_hyp_text, ref_text, and owsm_wer_*/owsm_cer_* counts
+        for delete, insert, replace, and equal; these are counts, not error rates.
+        Missing audio or text raises ValueError; inference failures propagate."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -277,10 +291,12 @@ class OwsmWerMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _owsm_wer_metadata()
 
 
 def _owsm_wer_metadata():
+    """Return registry metadata describing owsm wer inputs and dependencies."""
     return MetricMetadata(
         name="owsm_wer",
         category=MetricCategory.NON_MATCH,

--- a/versa/corpus_metrics/whisper_wer.py
+++ b/versa/corpus_metrics/whisper_wer.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Whisper corpus transcription and word, character, or phoneme error rates."""
 import logging
 
 import numpy as np
@@ -43,6 +44,10 @@ def whisper_wer_setup(
     use_gpu=True,
     cache_dir="versa_cache/whisper",
 ):
+    """Load Whisper and its text cleaner, optionally adding language-specific phonemizers.
+
+    The default tag selects large. Weights may be downloaded into cache_dir;
+    calc_per requires ESPnet phoneme tokenization support."""
     if model_tag == "default":
         model_tag = "large"
     device = "cuda" if use_gpu else "cpu"
@@ -69,6 +74,7 @@ def whisper_wer_setup(
 
 
 def _flatten_phonemes(tokens):
+    """Split underscore-separated phone tokens, discarding empty fragments."""
     return [phone for token in tokens for phone in token.strip().split("_") if phone]
 
 
@@ -205,6 +211,7 @@ class WhisperWerMetric(BaseMetric):
     """Whisper ASR-based WER/CER edit counts."""
 
     def _setup(self):
+        """Load the configured Whisper recognizer and retain decoding/cache settings."""
         self.model_tag = self.config.get("model_tag", "default")
         self.beam_size = self.config.get("beam_size", 5)
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
@@ -221,6 +228,17 @@ class WhisperWerMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return Whisper word/character edit counts for a mono utterance.
+
+        Require predictions and reference text in metadata text or a string
+        references argument. Use metadata sample_rate in Hz (default 16000),
+        resampling to 16 kHz for ASR without channel mixing. Return
+        whisper_hyp_text, ref_text, and whisper_wer_*/whisper_cer_* counts
+        for delete, insert, replace, and equal; these are counts, not error rates.
+        Missing audio or text raises ValueError; inference failures propagate.
+        Reuse whisper_hyp_text from metadata or general_cache when available.
+        When calc_per is enabled, also compute phoneme edit counts using the
+        detected or cached whisper_language/language value."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -252,10 +270,12 @@ class WhisperWerMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _whisper_wer_metadata()
 
 
 def _whisper_wer_metadata():
+    """Return registry metadata describing whisper wer inputs and dependencies."""
     return MetricMetadata(
         name="whisper_wer",
         category=MetricCategory.NON_MATCH,

--- a/versa/definition.py
+++ b/versa/definition.py
@@ -4,6 +4,7 @@
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
 
+"""Metric interfaces, discovery metadata, factories, and suites."""
 from abc import ABC, abstractmethod
 from typing import Dict, List, Optional, Any
 from dataclasses import dataclass
@@ -12,6 +13,8 @@ import logging
 
 
 class MetricCategory(Enum):
+    """Describe whether a metric needs paired, unpaired, or no reference audio."""
+
     INDEPENDENT = "independent"
     DEPENDENT = "dependent"
     NON_MATCH = "non_match"
@@ -19,6 +22,8 @@ class MetricCategory(Enum):
 
 
 class MetricType(Enum):
+    """Declare the kind of value exposed by a registered metric."""
+
     STRING = "string"
     FLOAT = "float"
     INT = "int"
@@ -32,6 +37,11 @@ class MetricType(Enum):
 
 @dataclass
 class MetricMetadata:
+    """Describe metric inputs, dependencies, capabilities, and provenance.
+
+    ``requires_multiple_sources`` means an ordered collection of source
+    waveforms is required, rather than a single waveform."""
+
     name: str
     category: MetricCategory
     metric_type: MetricType
@@ -50,6 +60,7 @@ class MetricRegistry:
     """Centralized registry for all metrics with automatic discovery."""
 
     def __init__(self):
+        """Create empty maps for metric classes, metadata, and aliases."""
         self._metrics: Dict[str, type] = {}
         self._metadata: Dict[str, MetricMetadata] = {}
         self._aliases: Dict[str, str] = {}
@@ -107,6 +118,10 @@ class BaseMetric(ABC):
     """Abstract base class for all metrics."""
 
     def __init__(self, config: Dict[str, Any] = None):
+        """Store configuration and immediately run the subclass setup hook.
+
+        Setup may load models or download assets; discovery should use metadata
+        instead of constructing metric instances."""
         self.config = config or {}
         self.logger = logging.getLogger(self.__class__.__name__)
         self._setup()
@@ -145,6 +160,7 @@ class GPUMetric(BaseMetric):
     """Base class for GPU-compatible metrics."""
 
     def __init__(self, config: Dict[str, Any] = None, device: str = "cuda"):
+        """Set the target device before running metric-specific initialization."""
         self.device = device
         super().__init__(config)
 
@@ -159,6 +175,7 @@ class MetricFactory:
     """Factory for creating metric instances with dependency management."""
 
     def __init__(self, registry: MetricRegistry):
+        """Bind a registry and initialize the cache of dependency import results."""
         self.registry = registry
         self._dependency_cache = {}
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -203,10 +220,12 @@ class MetricSuite:
     """Container for multiple metrics with batch processing capabilities."""
 
     def __init__(self, metrics: Dict[str, BaseMetric]):
+        """Retain the supplied name-to-instance mapping for suite evaluation."""
         self.metrics = metrics
         self.logger = logging.getLogger(self.__class__.__name__)
 
     def __len__(self) -> int:
+        """Return the number of metric instances in this suite."""
         return len(self.metrics)
 
     def compute_all(

--- a/versa/metric_discovery.py
+++ b/versa/metric_discovery.py
@@ -250,6 +250,7 @@ def supported_recommendation_tasks() -> Iterable[str]:
 
 @contextlib.contextmanager
 def _quiet_metric_imports():
+    """Temporarily suppress logging and stderr during optional metric imports."""
     previous_disable_level = logging.root.manager.disable
     logging.disable(logging.CRITICAL)
     with contextlib.redirect_stderr(io.StringIO()):
@@ -260,6 +261,7 @@ def _quiet_metric_imports():
 
 
 def _format_table(headers: List[str], rows: List[List[str]]) -> str:
+    """Render headers and rows as a left-aligned table with computed column widths."""
     widths = [
         max(len(str(row[index])) for row in [headers] + rows)
         for index in range(len(headers))
@@ -280,6 +282,7 @@ def _format_table(headers: List[str], rows: List[List[str]]) -> str:
 
 
 def _add_source_discovered_metrics(registry: MetricRegistry) -> None:
+    """Register source-derived placeholders for metrics not already registered."""
     package_root = Path(__file__).resolve().parent
     for path in package_root.rglob("*.py"):
         if path.name.startswith("__"):
@@ -291,6 +294,10 @@ def _add_source_discovered_metrics(registry: MetricRegistry) -> None:
 
 
 def _discover_module_metadata(path: Path) -> List[Tuple[Any, List[str]]]:
+    """Extract metadata and aliases from Python source without importing it.
+
+    Recognize literal constructors, local metadata helpers, and supported
+    prompt families. Unparseable source yields an empty list."""
     try:
         tree = ast.parse(path.read_text(encoding="utf-8"))
     except (SyntaxError, UnicodeDecodeError):
@@ -340,6 +347,7 @@ def _discover_module_metadata(path: Path) -> List[Tuple[Any, List[str]]]:
 
 
 def _discover_prompt_metrics(path: Path, tree: ast.AST) -> List[Tuple[Any, List[str]]]:
+    """Expand Qwen prompt names into metadata and aliases using source ASTs."""
     prompt_names = _default_prompt_names(tree)
     if not prompt_names and path.name == "qwen_omni.py":
         prompt_names = _default_prompt_names(
@@ -359,6 +367,7 @@ def _discover_prompt_metrics(path: Path, tree: ast.AST) -> List[Tuple[Any, List[
 
 
 def _default_prompt_names(tree: ast.AST) -> List[str]:
+    """Read literal string keys from the source assignment to DEFAULT_PROMPTS."""
     for node in ast.walk(tree):
         if not isinstance(node, ast.Assign):
             continue
@@ -381,6 +390,7 @@ def _metadata_from_register_call(
     assigned_metadata: Dict[str, Any],
     function_metadata: Dict[str, Any],
 ) -> Optional[Any]:
+    """Resolve the metadata argument of a registry call from known source values."""
     if len(node.args) < 2:
         return None
     metadata_arg = node.args[1]
@@ -394,6 +404,7 @@ def _metadata_from_register_call(
 
 
 def _metadata_from_known_helper(node: ast.Call) -> Optional[Any]:
+    """Evaluate only the supported dependency-light metadata helpers."""
     if not isinstance(node.func, ast.Name):
         return None
     helpers = {"_squim_metadata": _squim_metadata, "_scoreq_metadata": _scoreq_metadata}
@@ -405,6 +416,7 @@ def _metadata_from_known_helper(node: ast.Call) -> Optional[Any]:
 
 
 def _metadata_from_call(node: ast.AST) -> Optional[Any]:
+    """Build metadata from literal constructor arguments, or return None."""
     from versa.definition import MetricMetadata
 
     if not isinstance(node, ast.Call) or not _is_name(node.func, "MetricMetadata"):
@@ -444,6 +456,7 @@ def _metadata_from_call(node: ast.AST) -> Optional[Any]:
 
 
 def _literal_metric_value(node: ast.AST) -> Any:
+    """Decode literal AST values and metric enums without executing source code."""
     from versa.definition import MetricCategory, MetricType
 
     if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
@@ -467,6 +480,7 @@ def _literal_metric_value(node: ast.AST) -> Any:
 
 
 def _aliases_from_register_call(node: ast.Call) -> List[str]:
+    """Extract positional or keyword aliases, returning an empty list if unknown."""
     alias_node = None
     if len(node.args) >= 3:
         alias_node = node.args[2]
@@ -479,10 +493,12 @@ def _aliases_from_register_call(node: ast.Call) -> List[str]:
 
 
 def _is_register_call(node: ast.AST) -> bool:
+    """Recognize an attribute access named ``register`` in the source AST."""
     return isinstance(node, ast.Attribute) and node.attr == "register"
 
 
 def _is_name(node: ast.AST, name: str) -> bool:
+    """Check whether an AST node is a simple reference to the specified name."""
     return isinstance(node, ast.Name) and node.id == name
 
 
@@ -491,6 +507,7 @@ class _DiscoveredMetric:
 
 
 def _suggest_metric_names(registry: MetricRegistry, metric_name: str) -> List[str]:
+    """Return up to five sorted names or aliases containing the query, ignoring case."""
     query = metric_name.lower()
     names = set(registry.list_metrics()) | set(registry.list_aliases())
     return sorted(name for name in names if query in name.lower())[:5]

--- a/versa/metric_metadata.py
+++ b/versa/metric_metadata.py
@@ -7,6 +7,7 @@ from versa.definition import MetricCategory, MetricMetadata, MetricType
 
 
 def _qwen2_audio_metadata(name):
+    """Describe a named Qwen2-Audio prompt metric without importing its model."""
     return MetricMetadata(
         name=name,
         category=MetricCategory.INDEPENDENT,
@@ -23,6 +24,7 @@ def _qwen2_audio_metadata(name):
 
 
 def _qwen2_audio_aliases(metric_name):
+    """Return the legacy Qwen aliases for an unprefixed prompt name."""
     return [
         f"qwen2_{metric_name}_metric",
         f"qwen_{metric_name}",
@@ -30,6 +32,7 @@ def _qwen2_audio_aliases(metric_name):
 
 
 def _qwen_omni_metadata(name):
+    """Describe a named Qwen2.5-Omni prompt metric without importing its model."""
     return MetricMetadata(
         name=name,
         category=MetricCategory.INDEPENDENT,
@@ -46,10 +49,12 @@ def _qwen_omni_metadata(name):
 
 
 def _qwen_omni_aliases(metric_name):
+    """Return the legacy Omni alias for an unprefixed prompt name."""
     return [f"qwen_omni_{metric_name}_metric"]
 
 
 def _squim_metadata(name, mode):
+    """Describe SQUIM input requirements; only ``ref`` mode requires a reference."""
     requires_reference = mode == "ref"
     description = (
         "TorchAudio-SQUIM subjective MOS metric"
@@ -78,6 +83,7 @@ def _squim_metadata(name, mode):
 
 
 def _scoreq_metadata(name, mode):
+    """Describe ScoreQ input requirements and dependencies for the selected mode."""
     requires_reference = mode == "ref"
     description = (
         "ScoreQ reference-based speech quality assessment"

--- a/versa/metric_registry.py
+++ b/versa/metric_registry.py
@@ -10,6 +10,8 @@ from versa.definition import MetricRegistry
 
 @dataclass(frozen=True)
 class MetricModuleSpec:
+    """Identify an optional module, its exported symbols, and installation guidance."""
+
     module_name: str
     symbols: tuple
     install_hint: Optional[str] = None
@@ -334,6 +336,7 @@ def register_metric_for_config(
 
 
 def _has_concrete_metric(registry: MetricRegistry, metric_name: str) -> bool:
+    """Check that a registered class exposes runtime scoring and metadata methods."""
     metric_class = registry.get_metric(metric_name)
     if metric_class is None:
         return False
@@ -341,6 +344,7 @@ def _has_concrete_metric(registry: MetricRegistry, metric_name: str) -> bool:
 
 
 def _metric_spec_score(metric_name: str, spec: MetricModuleSpec) -> int:
+    """Rank likely module or symbol name matches ahead of unrelated metric modules."""
     query = _normalize_metric_name(metric_name)
     module_tail = _normalize_metric_name(spec.module_name.rsplit(".", 1)[-1])
     symbol_tails = [
@@ -354,10 +358,12 @@ def _metric_spec_score(metric_name: str, spec: MetricModuleSpec) -> int:
 
 
 def _normalize_metric_name(value: str) -> str:
+    """Lowercase a metric identifier and remove non-alphanumeric characters."""
     return "".join(character for character in value.lower() if character.isalnum())
 
 
 def _strip_symbol_affixes(symbol: str) -> str:
+    """Remove registry-function affixes to recover a candidate metric identifier."""
     if symbol.startswith("register_"):
         symbol = symbol[len("register_") :]
     if symbol.endswith("_metric"):
@@ -368,6 +374,7 @@ def _strip_symbol_affixes(symbol: str) -> str:
 def _try_import_metric_module(
     spec: MetricModuleSpec, logger: Optional[logging.Logger] = None
 ) -> Optional[Any]:
+    """Import an optional metric module, logging failures and returning None."""
     log = logger or logging.getLogger(__name__)
     try:
         return importlib.import_module(spec.module_name)

--- a/versa/reporting.py
+++ b/versa/reporting.py
@@ -102,6 +102,8 @@ METRIC_CATEGORIES = {
 
 @dataclass
 class MetricSummary:
+    """Hold finite-value statistics, completeness counts, extrema, and z-score outliers."""
+
     name: str
     category: str
     count: int
@@ -191,6 +193,7 @@ def analyze_records(
 
 
 def discover_numeric_metrics(records: Sequence[Dict[str, Any]]) -> List[str]:
+    """Find sorted numeric fields, excluding booleans, text, and internal fields."""
     metrics = set()
     for record in records:
         for key, value in record.items():
@@ -208,6 +211,12 @@ def summarize_metric(
     outlier_limit: int = 3,
     registry: Optional[MetricRegistry] = None,
 ) -> MetricSummary:
+    """Summarize finite values of one metric across result records.
+
+    Absent keys count as missing; nonnumeric and nonfinite values count as
+    invalid. Statistics are zero when no valid values exist. Confidence limits
+    use mean +/- 1.96 standard errors, and outliers have absolute z-score >= 2.
+    Unknown score direction is ranked as higher-is-better for extrema."""
     values: List[Tuple[str, float]] = []
     missing = 0
     invalid = 0
@@ -283,6 +292,10 @@ def summarize_groups(
     group_by: str,
     registry: Optional[MetricRegistry] = None,
 ) -> Dict[str, Any]:
+    """Group records by a field and rank group means separately for each metric.
+
+    Missing group fields become ``unknown``. Groups with no finite values for
+    a metric are omitted from its ranking; unknown direction sorts descending."""
     grouped: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
     for record in records:
         grouped[str(record.get(group_by, "unknown"))].append(record)
@@ -316,6 +329,7 @@ def summarize_groups(
 
 
 def write_csv_report(analysis: Dict[str, Any], output_path: str) -> None:
+    """Overwrite a UTF-8 CSV with one row per metric from ``analyze_records``."""
     fields = [
         "metric",
         "category",
@@ -345,6 +359,7 @@ def write_csv_report(analysis: Dict[str, Any], output_path: str) -> None:
 
 
 def write_markdown_report(analysis: Dict[str, Any], output_path: str) -> None:
+    """Overwrite a UTF-8 Markdown summary and outlier report from an analysis."""
     lines = [
         "# VERSA Results Report",
         "",
@@ -388,6 +403,7 @@ def write_markdown_report(analysis: Dict[str, Any], output_path: str) -> None:
 
 
 def write_html_report(analysis: Dict[str, Any], output_path: str) -> None:
+    """Overwrite a self-contained HTML report with summaries, charts, and rankings."""
     category_rows = []
     for category, summaries in analysis["categories"].items():
         expected_values = analysis["record_count"] * len(summaries)
@@ -478,6 +494,7 @@ svg text {{ font-family: inherit; fill: var(--muted); font-size: 11px; }}
 
 
 def metric_category(metric: str, registry: Optional[MetricRegistry] = None) -> str:
+    """Infer a reporting category from registry metadata and metric-name heuristics."""
     metadata = _metadata_for_metric(metric, registry)
     if metadata and metadata.category.value in {"non_match", "distributional"}:
         return metadata.category.value
@@ -503,6 +520,9 @@ def metric_category(metric: str, registry: Optional[MetricRegistry] = None) -> s
 def metric_direction(
     metric: str, registry: Optional[MetricRegistry] = None
 ) -> Optional[bool]:
+    """Infer whether larger scores are better, returning None for unknown names.
+
+    This is a name-based heuristic, not a backend-provided score guarantee."""
     metadata = _metadata_for_metric(metric, registry)
     normalized = _strip_prefix(metadata.name if metadata else metric).lower()
     if any(token in normalized for token in ["wer", "cer", "error", "rmse", "mcd"]):
@@ -533,6 +553,7 @@ def metric_direction(
 
 
 def _metadata_for_metric(metric: str, registry: Optional[MetricRegistry]):
+    """Find the first registry entry matching a metric name or stripped suffix."""
     if registry is None:
         return None
     for candidate in _metric_name_candidates(metric):
@@ -543,6 +564,7 @@ def _metadata_for_metric(metric: str, registry: Optional[MetricRegistry]):
 
 
 def _metric_name_candidates(metric: str) -> List[str]:
+    """Return distinct metric identifiers obtained by progressively removing prefixes."""
     candidates = [metric, _strip_prefix(metric)]
     parts = metric.split("_")
     for index in range(1, len(parts)):
@@ -555,6 +577,9 @@ def _metric_name_candidates(metric: str) -> List[str]:
 
 
 def _collect_input_paths(input_path: str) -> List[Path]:
+    """List a result file or supported files directly inside a directory.
+
+    Raise FileNotFoundError if the path contains no recognized result files."""
     path = Path(input_path)
     if path.is_file():
         return [path]
@@ -568,8 +593,13 @@ def _collect_input_paths(input_path: str) -> List[Path]:
 
 
 def _literal_eval_with_special_floats(line: str) -> Any:
+    """Parse a Python literal record allowing bare infinity and NaN spellings."""
+
     class SpecialFloatTransformer(ast.NodeTransformer):
+        """Replace supported special-float names with constants before literal evaluation."""
+
         def visit_Name(self, node: ast.Name) -> ast.AST:
+            """Convert inf/Infinity and nan/NaN names while preserving source locations."""
             if node.id in {"inf", "Infinity"}:
                 return ast.copy_location(ast.Constant(float("inf")), node)
             if node.id in {"nan", "NaN"}:
@@ -583,6 +613,7 @@ def _literal_eval_with_special_floats(line: str) -> Any:
 
 
 def _to_float(value: Any) -> Optional[float]:
+    """Convert numeric scalars to float; reject booleans and nonnumeric values."""
     if isinstance(value, bool):
         return None
     if isinstance(value, (int, float)):
@@ -591,6 +622,7 @@ def _to_float(value: Any) -> Optional[float]:
 
 
 def _sample_std(values: Sequence[float], mean: float) -> float:
+    """Return sample standard deviation, or zero for fewer than two observations."""
     if len(values) <= 1:
         return 0.0
     variance = sum((value - mean) ** 2 for value in values) / (len(values) - 1)
@@ -598,6 +630,7 @@ def _sample_std(values: Sequence[float], mean: float) -> float:
 
 
 def _median(sorted_values: Sequence[float]) -> float:
+    """Return the median of already-sorted values, or zero for an empty sequence."""
     count = len(sorted_values)
     if not count:
         return 0.0
@@ -608,6 +641,7 @@ def _median(sorted_values: Sequence[float]) -> float:
 
 
 def _strip_prefix(metric: str) -> str:
+    """Remove one prefix only if the remainder is a known reporting metric."""
     parts = metric.split("_")
     if len(parts) > 1 and parts[0] not in {"se", "si", "ci", "f0"}:
         candidate = "_".join(parts[1:])
@@ -618,6 +652,7 @@ def _strip_prefix(metric: str) -> str:
 
 
 def _fmt(value: Any) -> str:
+    """Format finite floats to four significant digits and stringify other values."""
     if isinstance(value, float):
         if not math.isfinite(value):
             return str(value)
@@ -626,6 +661,7 @@ def _fmt(value: Any) -> str:
 
 
 def _summary_row(summary: MetricSummary) -> Dict[str, Any]:
+    """Convert a metric summary to CSV fields, flattening its outlier list."""
     return {
         "metric": summary.name,
         "category": summary.category,
@@ -653,6 +689,7 @@ def _summary_row(summary: MetricSummary) -> Dict[str, Any]:
 
 
 def _metric_html_row(summary: MetricSummary) -> str:
+    """Render one metric summary as a table row with escaped names and keys."""
     ci = f"{_fmt(summary.ci95_low)} to {_fmt(summary.ci95_high)}"
     best = f"{html.escape(summary.best_key)} ({_fmt(summary.best_value)})"
     worst = f"{html.escape(summary.worst_key)} ({_fmt(summary.worst_value)})"
@@ -673,6 +710,7 @@ def _metric_html_row(summary: MetricSummary) -> str:
 
 
 def _outlier_html(summaries: Sequence[MetricSummary]) -> str:
+    """Render escaped outlier lists, or a message when no outliers were found."""
     blocks = []
     for summary in summaries:
         if not summary.outliers:
@@ -690,6 +728,7 @@ def _outlier_html(summaries: Sequence[MetricSummary]) -> str:
 
 
 def _ranking_html(analysis: Dict[str, Any]) -> str:
+    """Render the top group for each ranked metric, or empty text if none exist."""
     groups = analysis.get("groups") or {}
     rankings = groups.get("rankings") or {}
     if not rankings:
@@ -709,6 +748,9 @@ def _ranking_html(analysis: Dict[str, Any]) -> str:
 
 
 def _radar_svg(summaries: Sequence[MetricSummary]) -> str:
+    """Plot absolute means scaled to the largest absolute mean in this selection.
+
+    The plot does not normalize metric ranges or account for score direction."""
     if not summaries:
         return '<p class="muted">No metrics available.</p>'
     width = 420
@@ -758,6 +800,7 @@ def _radar_svg(summaries: Sequence[MetricSummary]) -> str:
 
 
 def _sunburst_svg(category_rows: Sequence[Dict[str, Any]]) -> str:
+    """Render category wedges sized by their number of metrics."""
     if not category_rows:
         return '<p class="muted">No categories available.</p>'
     width = 420
@@ -809,6 +852,7 @@ def _arc_path(
     end: float,
     color: str,
 ) -> str:
+    """Build a filled SVG annular sector from radii and angles in radians."""
     large = 1 if end - start > math.pi else 0
     p1 = (cx + math.cos(start) * outer, cy + math.sin(start) * outer)
     p2 = (cx + math.cos(end) * outer, cy + math.sin(end) * outer)

--- a/versa/scorer_shared.py
+++ b/versa/scorer_shared.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Shared scoring, result persistence, resume, and multi-source orchestration."""
 import gc
 import json
 import logging
@@ -74,6 +75,10 @@ def _score_utterance_worker(utterance):
 
 def audio_loader_setup(audio, io):
     # get ready compute embeddings
+    """Build an utterance mapping from a Kaldi SCP, soundfile SCP, or directory.
+
+    Kaldi entries load lazily. Soundfile SCP values are paths; command pipes
+    raise ValueError and require the Kaldi interface instead."""
     if io == "kaldi":
         audio_files = kaldiio.load_scp(audio)
     elif io == "dir":
@@ -370,6 +375,10 @@ class ScoreProcessor:
         output_file: Optional[str] = None,
         resume: bool = False,
     ):
+        """Bind a metric suite and optionally open its result file.
+
+        Resume appends, repairing a missing final newline first. Otherwise the
+        file is truncated. The processor owns the handle and must be closed."""
         self.metric_suite = metric_suite
         self.output_file = output_file
         self.logger = logging.getLogger(self.__class__.__name__)
@@ -434,6 +443,7 @@ class VersaScorer:
     """Main scorer class that orchestrates the scoring process."""
 
     def __init__(self, registry: MetricRegistry = None):
+        """Bind a registry, or create metadata-only discovery, and prepare its factory."""
         self.registry = registry or self._create_default_registry()
         self.factory = MetricFactory(self.registry)
         self.logger = logging.getLogger(self.__class__.__name__)

--- a/versa/sequence_metrics/__init__.py
+++ b/versa/sequence_metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Sequence-aligned metric implementations."""

--- a/versa/sequence_metrics/mcd_f0.py
+++ b/versa/sequence_metrics/mcd_f0.py
@@ -4,6 +4,7 @@
 # Adapted/Inspired by ESPnet/S3PRL-VC from Wen-Chin Huang and Tomoki Hayashi
 # Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""WORLD-based mel-cepstral distortion and pitch comparison."""
 import logging
 
 import numpy as np
@@ -26,6 +27,7 @@ except ImportError:
 
 
 def _ensure_mcd_f0_dependencies():
+    """Raise ImportError if a required WORLD, SPTK, SciPy, or DTW component is absent."""
     if any(
         dependency is None
         for dependency in (pysptk, pw, scipy, fastdtw, firwin, lfilter)
@@ -154,6 +156,11 @@ def world_extract(
     mcep_alpha=0.466,
     filter_cutoff=70,
 ):
+    """Extract WORLD spectra, mel cepstra, aperiodicity, F0, and normalized power.
+
+    Input is floating audio at fs Hz; sample-by-channel input uses channel 0.
+    Scale to int16 amplitude and low-cut filter before analysis. F0 bounds
+    and filter cutoff use Hz; mcep_shift is milliseconds and mcep_fftl is samples."""
     _ensure_mcd_f0_dependencies()
     # scale from [-1, 1] to [-32768, 32767]
     x = x * np.iinfo(np.int16).max
@@ -199,6 +206,12 @@ def mcd_f0(
     power_threshold=-20,
     dtw=False,
 ):
+    """Compare WORLD features using optional DTW or truncated frame alignment.
+
+    Inputs share fs in Hz and use their first channel. Return mcd in dB,
+    f0rmse in Hz (lower is better), and f0corr (higher is better). Non-DTW
+    alignment asserts the sequence mismatch is below the configured fraction.
+    DTW filters low-power frames; failed voiced-frame comparisons may yield NaN."""
     _ensure_mcd_f0_dependencies()
 
     pred_feats = world_extract(
@@ -290,6 +303,7 @@ class McdF0Metric(BaseMetric):
     """Mel cepstral distortion and F0 metrics."""
 
     def _setup(self):
+        """Check analysis dependencies and retain pitch, cepstral, and alignment settings."""
         _ensure_mcd_f0_dependencies()
         self.f0min = self.config.get("f0min", 40)
         self.f0max = self.config.get("f0max", 800)
@@ -302,6 +316,12 @@ class McdF0Metric(BaseMetric):
         self.dtw = self.config.get("dtw", False)
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return mcd, f0rmse, and f0corr for a required prediction/reference pair.
+
+        Read shared sample_rate in Hz from metadata (default 16000); no resampling
+        is performed. Mono or sample-by-channel arrays use the first channel.
+        Missing audio raises ValueError; feature extraction and alignment behavior
+        follow ``mcd_f0``, including possible NaN pitch results."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -324,10 +344,12 @@ class McdF0Metric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _mcd_f0_metadata()
 
 
 def _mcd_f0_metadata():
+    """Return registry metadata describing mcd f0 inputs and dependencies."""
     return MetricMetadata(
         name="mcd_f0",
         category=MetricCategory.DEPENDENT,

--- a/versa/sequence_metrics/signal_metric.py
+++ b/versa/sequence_metrics/signal_metric.py
@@ -4,6 +4,7 @@
 # Mainly adpated from ESPnet-SE (https://github.com/espnet/espnet.git)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Reference-based SDR, SIR, SAR, SI-SNR, and CI-SDR scoring."""
 import ci_sdr
 import fast_bss_eval
 import numpy as np
@@ -15,6 +16,11 @@ from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricT
 
 def calculate_si_snr(pred_x, gt_x, zero_mean=None, clamp_db=None, pairwise=False):
     # TODO(jiatong): pass zero_mean and clamp_db setup to the function
+    """Return scalar SI-SNR in dB by negating fast_bss_eval loss.
+
+    Inputs are NumPy source/sample arrays yielding a single loss value.
+    Forward zero_mean, clamp_db, and pairwise to the backend; a multi-element
+    loss cannot be converted to the scalar returned by this implementation."""
     pred_x = torch.from_numpy(pred_x).float()
     gt_x = torch.from_numpy(gt_x).float()
 
@@ -30,6 +36,10 @@ def calculate_si_snr(pred_x, gt_x, zero_mean=None, clamp_db=None, pairwise=False
 
 def calculate_ci_sdr(pred_x, gt_x, filter_length=512):
     # TODO(jiatong): pass filter_length to the function
+    """Return scalar CI-SDR in dB with the given filter length in samples.
+
+    Source/sample NumPy arrays must yield one loss value. Source permutation
+    is disabled; multi-element backend losses cannot be converted to float."""
     pred_x = torch.from_numpy(pred_x).float()
     gt_x = torch.from_numpy(gt_x).float()
 
@@ -41,6 +51,12 @@ def calculate_ci_sdr(pred_x, gt_x, filter_length=512):
 
 def signal_metric(pred_x, gt_x):
     # Expected input: (channel, samples)
+    """Return sdr, sir, sar, si_snr, and ci_sdr in dB for a single-source pair.
+
+    Accept mono ``(samples,)`` or ``(1, samples)`` arrays and truncate unequal
+    lengths to the shorter input. No resampling, channel mixing, or source
+    permutation is performed. Although 2D input is accepted, multiple sources
+    are unsupported by the scalar SI-SNR/CI-SDR helpers. Scores are not clipped."""
     if pred_x.ndim == 1:
         pred_x = pred_x[np.newaxis, :]
     if gt_x.ndim == 1:
@@ -65,9 +81,15 @@ class SignalMetric(BaseMetric):
     """Reference-based signal distortion metrics."""
 
     def _setup(self):
+        """Use the stateless signal-metric functions without model initialization."""
         pass
 
     def compute(self, predictions, references=None, metadata=None):
+        """Score required single-source prediction/reference arrays with ``signal_metric``.
+
+        Inputs must already share a sample rate; metadata is unused. Return five
+        signal ratios in dB. Missing either array raises ValueError; backend
+        validation errors propagate."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -75,10 +97,12 @@ class SignalMetric(BaseMetric):
         return signal_metric(np.asarray(predictions), np.asarray(references))
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _signal_metadata()
 
 
 def _signal_metadata():
+    """Return registry metadata describing signal metric inputs and dependencies."""
     return MetricMetadata(
         name="signal_metric",
         category=MetricCategory.DEPENDENT,

--- a/versa/sequence_metrics/warpq.py
+++ b/versa/sequence_metrics/warpq.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Dynamic-time-warping speech quality assessment with WARP-Q."""
 import logging
 
 import numpy as np
@@ -30,6 +31,9 @@ def warpq_setup(
     sigma=[[1, 0], [0, 3], [1, 3]],
     apply_vad=False,
 ):
+    """Construct WARP-Q with MFCC, DTW, and optional VAD settings, without MOS mapping.
+
+    fs/fmax are Hz and patch_size is seconds. Missing WARP-Q raises ImportError."""
     args = {
         "sr": fs,
         "n_mfcc": n_mfcc,
@@ -69,6 +73,7 @@ class WarpqMetric(BaseMetric):
     """WARP-Q dynamic time warping cost metric."""
 
     def _setup(self):
+        """Create a WARP-Q evaluator with configured sample rate and alignment settings."""
         self.fs = self.config.get("fs", 8000)
         self.n_mfcc = self.config.get("n_mfcc", 13)
         self.fmax = self.config.get("fmax", 4000)
@@ -85,6 +90,12 @@ class WarpqMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ``warpq`` DTW cost for a required mono prediction/reference pair.
+
+        Use shared metadata sample_rate in Hz (default 16000) and resample to
+        the configured WARP-Q rate (default 8000). No channel mixing is performed.
+        The raw cost is returned without MOS mapping; missing inputs raise ValueError.
+        """
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -99,10 +110,12 @@ class WarpqMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _warpq_metadata()
 
 
 def _warpq_metadata():
+    """Return registry metadata describing warpq inputs and dependencies."""
     return MetricMetadata(
         name="warpq",
         category=MetricCategory.DEPENDENT,

--- a/versa/utils_shared.py
+++ b/versa/utils_shared.py
@@ -3,6 +3,7 @@
 # Copyright 2025 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Audio loading, waveform conversion, and serialization helpers for scoring."""
 import copy
 import fnmatch
 import logging
@@ -43,6 +44,7 @@ def find_files(
 
 
 def check_all_same(array):
+    """Return whether all samples equal the first; warn and return True if empty."""
     try:
         return np.all(array == array[0])
     except IndexError:
@@ -51,6 +53,10 @@ def check_all_same(array):
 
 
 def load_audio(info, io):
+    """Return ``(sample_rate, waveform)`` from a Kaldi pair or soundfile path.
+
+    The ``soundfile`` and ``dir`` modes preserve the file channel layout.
+    Unknown I/O modes raise NotImplementedError."""
     if io == "kaldi":
         gen_sr, gen_wav = info
     elif io == "soundfile" or io == "dir":
@@ -61,6 +67,10 @@ def load_audio(info, io):
 
 
 def wav_normalize(wave_array):
+    """Copy audio to contiguous float64, selecting the first channel if needed.
+
+    Input channels occupy the last axis. Only int16 input is amplitude-scaled,
+    by the maximum int16 value; other dtypes retain their original scale."""
     if wave_array.ndim > 1:
         wave_array = wave_array[:, 0]
         logging.warning(
@@ -78,6 +88,7 @@ def wav_normalize(wave_array):
 
 
 def check_minimum_length(length, key_info):
+    """Check duration in seconds against minimum lengths for the named metrics."""
     if "stoi" in key_info:
         # NOTE(jiatong): explicitly 0.256s as in https://github.com/mpariente/pystoi/pull/24
         if length < 0.3:

--- a/versa/utterance_metrics/__init__.py
+++ b/versa/utterance_metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Utterance-level metric implementations."""

--- a/versa/utterance_metrics/arecho.py
+++ b/versa/utterance_metrics/arecho.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""ARECHO speech-quality model loading and utterance scoring."""
 import numpy as np
 import torch
 import librosa
@@ -158,6 +159,7 @@ class ArechoMetric(BaseMetric):
     """ARECHO no-reference speech quality metric."""
 
     def _setup(self):
+        """Load the ARECHO model, using the configured ESPnet model-zoo cache and device."""
         self.model_tag = self.config.get("model_tag", "default")
         self.use_gpu = self.config.get("use_gpu", False)
         self.cache_dir = self.config.get("cache_dir", "versa_cache/espnet_model_zoo")
@@ -168,6 +170,12 @@ class ArechoMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ARECHO quality outputs for mono predictions using a silent reference.
+
+        The sample rate comes from metadata in Hz (default 16000); predictions
+        are resampled to 16 kHz without channel mixing. References are unused.
+        Return backend dimensions with ``arecho_`` prefixes, or ``arecho_score``
+        for scalar output, without clipping. Missing predictions raise ValueError."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         metadata = metadata or {}
@@ -176,10 +184,12 @@ class ArechoMetric(BaseMetric):
         return arecho_noref_metric(self.model, pred_x, fs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _arecho_metadata()
 
 
 def _arecho_metadata():
+    """Return registry metadata describing arecho inputs and dependencies."""
     return MetricMetadata(
         name="arecho",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/asr_matching.py
+++ b/versa/utterance_metrics/asr_matching.py
@@ -101,7 +101,7 @@ class ASRMatchMetric(BaseMetric):
         return MetricMetadata(
             name="asr_match",
             category=MetricCategory.DEPENDENT,
-            metric_type=MetricType.FLOAT,
+            metric_type=MetricType.DICT,
             requires_reference=True,
             requires_text=False,
             gpu_compatible=True,
@@ -118,7 +118,7 @@ def register_asr_match_metric(registry):
     metric_metadata = MetricMetadata(
         name="asr_match",
         category=MetricCategory.DEPENDENT,
-        metric_type=MetricType.FLOAT,
+        metric_type=MetricType.DICT,
         requires_reference=True,
         requires_text=False,
         gpu_compatible=True,

--- a/versa/utterance_metrics/asr_matching.py
+++ b/versa/utterance_metrics/asr_matching.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Whisper-based transcription mismatch between paired audio recordings."""
 import logging
 from typing import Dict, Optional, Union, Any
 
@@ -57,6 +58,7 @@ class ASRMatchMetric(BaseMetric):
     """ASR-oriented Mismatch Error Rate (ASR-Match) metric using Whisper."""
 
     def _setup(self):
+        """Load Whisper and retain decoding, cleaning, device, and download-cache settings."""
         self.model_tag = self.config.get("model_tag", "default")
         self.beam_size = self.config.get("beam_size", 5)
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
@@ -73,6 +75,13 @@ class ASRMatchMetric(BaseMetric):
     def compute(
         self, predictions: Any, references: Any = None, metadata: Dict[str, Any] = None
     ) -> Dict[str, Union[float, str]]:
+        """Compare Whisper transcripts of required mono prediction/reference audio.
+
+        Use shared metadata sample_rate in Hz (default 16000) and optionally
+        cache_pred_text to skip prediction transcription. Resample to 16 kHz
+        without channel mixing. Return asr_match edit counts, error rate, and
+        transcripts; missing inputs raise ValueError and ASR failures raise RuntimeError.
+        """
         pred_x = predictions
         gt_x = references
         fs = 16000
@@ -88,6 +97,7 @@ class ASRMatchMetric(BaseMetric):
         return asr_match_metric(self.wer_utils, pred_x, gt_x, cache_pred_text, fs)
 
     def get_metadata(self) -> MetricMetadata:
+        """Return input requirements and provenance for this metric configuration."""
         return MetricMetadata(
             name="asr_match",
             category=MetricCategory.DEPENDENT,

--- a/versa/utterance_metrics/chroma_alignment.py
+++ b/versa/utterance_metrics/chroma_alignment.py
@@ -4,6 +4,7 @@
 # Chroma-based distance estimation with dynamic programming alignment
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Chroma feature alignment for comparing musical audio."""
 import logging
 from typing import Dict, Any, Optional, Union, Tuple, List
 

--- a/versa/utterance_metrics/discrete_speech.py
+++ b/versa/utterance_metrics/discrete_speech.py
@@ -41,6 +41,7 @@ from versa.huggingface_cache import (
 
 
 def _get_discrete_speech_cache_dir(config_cache_dir=None):
+    """Resolve the k-means cache from environment, explicit configuration, or default."""
     return (
         os.environ.get(DISCRETE_SPEECH_CACHE_ENV)
         or config_cache_dir
@@ -55,6 +56,7 @@ def _patch_transformers_loaders(cache_dir):
     from discrete_speech_metrics import speechtokendistance
 
     def patch_model(model_cls, repo_id):
+        """Wrap a model loader once per patch using its saved original implementation."""
         original = getattr(
             model_cls.from_pretrained,
             "_versa_original_from_pretrained",
@@ -62,6 +64,7 @@ def _patch_transformers_loaders(cache_dir):
         )
 
         def from_pretrained(pretrained_model_name_or_path, *args, **kwargs):
+            """Load weights with VERSA cache defaults and use local files when already cached."""
             kwargs.setdefault("cache_dir", str(cache_dir))
             kwargs.setdefault("use_safetensors", False)
             kwargs.update(
@@ -87,12 +90,14 @@ def _patch_transformers_loaders(cache_dir):
 
 
 def _patch_kmeans_loaders(kmeans_cache_dir):
+    """Redirect third-party k-means constructors to visible cached centroid files."""
     from discrete_speech_metrics import speechbleu
     from discrete_speech_metrics import speechtokendistance
 
     kmeans_dir = Path(kmeans_cache_dir).resolve() / "km"
 
     def patch_module(module):
+        """Replace a module k-means class while preserving its original constructor."""
         original_apply_kmeans = getattr(
             module.ApplyKmeans,
             "_versa_original_apply_kmeans",
@@ -100,7 +105,10 @@ def _patch_kmeans_loaders(kmeans_cache_dir):
         )
 
         class VisibleCacheApplyKmeans(original_apply_kmeans):
+            """Prefer VERSA centroid files over the backend path when the cached file exists."""
+
             def __init__(self, km_path, device):
+                """Resolve the centroid basename in the visible cache and initialize on device."""
                 visible_path = kmeans_dir / Path(km_path).name
                 super().__init__(
                     visible_path if visible_path.exists() else km_path, device
@@ -114,6 +122,9 @@ def _patch_kmeans_loaders(kmeans_cache_dir):
 
 
 def _load_discrete_speech_classes(cache_dir, kmeans_cache_dir):
+    """Import metric classes lazily and patch their Hugging Face and centroid caches.
+
+    Store imported classes globally; raise ImportError when the backend is absent."""
     global SpeechBERTScore, SpeechBLEU, SpeechTokenDistance
 
     if not DISCRETE_SPEECH_AVAILABLE:

--- a/versa/utterance_metrics/dpam_distance.py
+++ b/versa/utterance_metrics/dpam_distance.py
@@ -22,7 +22,10 @@ from versa.definition import BaseMetric, MetricMetadata, MetricCategory, MetricT
 
 
 class lossnet(nn.Module):
+    """Learn channel-weighted perceptual distances between paired waveforms."""
+
     def __init__(self, nconv=14, nchan=32, dp=0.1, dist_act="no"):
+        """Build strided convolution blocks, learned channel weights, and distance activation."""
         super(lossnet, self).__init__()
         self.nconv = nconv
         self.dist_act = dist_act
@@ -67,6 +70,10 @@ class lossnet(nn.Module):
             self.act = None
 
     def forward(self, xref, xper):
+        """Return one perceptual distance per batch item from paired batch/sample tensors.
+
+        Move inputs to the model device, accumulate weighted feature differences
+        across layers, and apply the configured final distance activation."""
         device = next(self.parameters()).device
         xref = xref.unsqueeze(1).to(device)
         xper = xper.unsqueeze(1).to(device)

--- a/versa/utterance_metrics/emo_vad.py
+++ b/versa/utterance_metrics/emo_vad.py
@@ -66,7 +66,7 @@ class RegressionHead(nn.Module):
     r"""Classification head."""
 
     def __init__(self, config):
-
+        """Construct the dropout and dense layers for emotion-dimension regression."""
         super().__init__()
 
         self.dense = nn.Linear(config.hidden_size, config.hidden_size)
@@ -74,7 +74,7 @@ class RegressionHead(nn.Module):
         self.out_proj = nn.Linear(config.hidden_size, config.num_labels)
 
     def forward(self, features, **kwargs):
-
+        """Project pooled features into emotion logits using dropout and tanh."""
         x = features
         x = self.dropout(x)
         x = self.dense(x)
@@ -91,7 +91,7 @@ if TRANSFORMERS_AVAILABLE:
         r"""Speech emotion classifier."""
 
         def __init__(self, config):
-
+            """Initialize the Wav2Vec2 encoder and emotion regression head from config."""
             super().__init__(config)
 
             self.config = config
@@ -104,7 +104,7 @@ if TRANSFORMERS_AVAILABLE:
             self,
             input_values,
         ):
-
+            """Return mean-pooled encoder embeddings and emotion logits for batched audio."""
             outputs = self.wav2vec2(input_values)
             hidden_states = outputs[0]
             hidden_states = torch.mean(hidden_states, dim=1)
@@ -119,6 +119,7 @@ else:
 
         @classmethod
         def from_pretrained(cls, *args, **kwargs):
+            """Raise installation guidance when the optional Transformers backend is absent."""
             raise ImportError(
                 "transformers is not properly installed. "
                 "Please install transformers and retry"

--- a/versa/utterance_metrics/log_wmse.py
+++ b/versa/utterance_metrics/log_wmse.py
@@ -21,11 +21,13 @@ except ImportError:
 
 
 def _ensure_log_wmse_available():
+    """Raise ImportError with installation guidance if torch-log-wmse is absent."""
     if LogWMSE is None:
         raise ImportError("Please install torch-log-wmse and retry")
 
 
 def _as_unprocessed_tensor(audio):
+    """Convert audio to float tensors with batch/channel axes for 1D or 2D input."""
     if isinstance(audio, torch.Tensor):
         tensor = audio.float()
     else:
@@ -38,6 +40,7 @@ def _as_unprocessed_tensor(audio):
 
 
 def _as_stem_tensor(audio):
+    """Add a stem axis to a three-dimensional batch/channel/sample tensor."""
     tensor = _as_unprocessed_tensor(audio)
     if tensor.ndim == 3:
         tensor = tensor.unsqueeze(1)
@@ -81,6 +84,7 @@ class LogWmseMetric(BaseMetric):
     """Log-weighted mean square error."""
 
     def _setup(self):
+        """Construct LogWMSE with the configured audio duration, sample rate, and sign."""
         _ensure_log_wmse_available()
         self.audio_length = self.config.get("audio_length", 1.0)
         self.sample_rate = self.config.get("sample_rate", 44100)
@@ -97,6 +101,14 @@ class LogWmseMetric(BaseMetric):
         self.model = LogWMSE(**kwargs)
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ``log_wmse`` for processed predictions and clean references.
+
+        Use ``metadata["unprocessed"]`` or ``unproc_x`` for the original mixture,
+        falling back to predictions. Mono and channel/sample arrays are expanded
+        to batch/stem/channel/sample tensors. No resampling occurs here: the model
+        uses the configured sample_rate (default 44100), not the metadata rate.
+        The output retains backend scaling and the configured return_as_loss sign.
+        Missing predictions or references raise ValueError."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -114,10 +126,12 @@ class LogWmseMetric(BaseMetric):
         return log_wmse(unproc_x, proc_x, gt_x, fs, model=self.model)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _log_wmse_metadata()
 
 
 def _log_wmse_metadata():
+    """Return registry metadata describing log wmse inputs and dependencies."""
     return MetricMetadata(
         name="log_wmse",
         category=MetricCategory.DEPENDENT,

--- a/versa/utterance_metrics/mapss.py
+++ b/versa/utterance_metrics/mapss.py
@@ -18,6 +18,7 @@ except ImportError:
 
 
 def _require_mapss():
+    """Raise an actionable ImportError when the optional MAPSS backend is absent."""
     if mapss_compute is None:
         raise ImportError(
             "MAPSS is an optional dependency. Install the pinned backend with "
@@ -26,11 +27,13 @@ def _require_mapss():
 
 
 def _safe_path_component(value):
+    """Replace unsafe path characters and provide ``mixture`` for an empty result."""
     component = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value)).strip("._")
     return component or "mixture"
 
 
 def _result_directory_name(value):
+    """Append an eight-character key hash to a sanitized result directory name."""
     text = str(value)
     digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:8]
     return f"{_safe_path_component(text)}-{digest}"
@@ -61,6 +64,10 @@ class MapssMetric(BaseMetric):
     """Manifold-based perceptual assessment for ordered separated sources."""
 
     def _setup(self):
+        """Validate backend availability and retain model and artifact settings.
+
+        The backend model is invoked during compute; results are saved under
+        ``cache_dir/results`` (default ``versa_cache/mapss/results``)."""
         _require_mapss()
         self.model = self.config.get("model", "wav2vec2")
         self.layer = self.config.get("layer")
@@ -75,6 +82,25 @@ class MapssMetric(BaseMetric):
         self.max_gpus = int(self.config.get("use_gpu", False))
 
     def compute(self, predictions, references=None, metadata=None):
+        """Score ordered separated sources and save MAPSS diagnostic artifacts.
+
+        Args:
+            predictions: List or tuple of at least two mono source waveforms.
+            references: Equally sized ordered reference list; source i must match
+                prediction i. This wrapper does not search for a permutation.
+            metadata: Optional ``sample_rate`` in Hz (default 16000) and mixture
+                ``key`` used to derive the artifact directory.
+
+        Returns:
+            Per-source ``mapss_ps_<source>`` and ``mapss_pm_<source>`` floats from
+            the backend summary, plus ``mapss_result_dir``. Values retain backend
+            scaling; this wrapper does not clip or normalize them.
+
+        Raises:
+            ValueError: Source collections are invalid or normalized names collide.
+
+        Backend model loading and result saving may download assets or write files.
+        Length handling and confidence intervals follow the configured MAPSS policy."""
         if not isinstance(predictions, (list, tuple)) or len(predictions) < 2:
             raise ValueError(
                 "MAPSS requires at least two ordered predicted source waveforms"
@@ -114,10 +140,12 @@ class MapssMetric(BaseMetric):
         return scores
 
     def get_metadata(self):
+        """Return the MAPSS input requirements and backend provenance."""
         return _mapss_metadata()
 
 
 def _mapss_metadata():
+    """Declare ordered-reference requirements and optional MAPSS dependencies."""
     return MetricMetadata(
         name="mapss",
         category=MetricCategory.DEPENDENT,
@@ -137,6 +165,7 @@ def _mapss_metadata():
 
 
 def register_mapss_metric(registry):
+    """Register the MAPSS wrapper and its public aliases in the supplied registry."""
     registry.register(
         MapssMetric,
         _mapss_metadata(),

--- a/versa/utterance_metrics/multigauss.py
+++ b/versa/utterance_metrics/multigauss.py
@@ -153,6 +153,7 @@ class MultiGaussMetric(BaseMetric):
     """Multivariate probabilistic speech quality assessment."""
 
     def _setup(self):
+        """Load the MultiGauss head and XLSR encoder, caching downloaded encoder weights."""
         self.model = multigauss_model_setup(
             model_tag=self.config.get("model_tag", "probabilistic"),
             cache_dir=self.config.get("cache_dir", "versa_cache"),
@@ -160,6 +161,14 @@ class MultiGaussMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return MultiGauss quality dimensions and optional covariance for mono audio.
+
+        The input rate is ``metadata["sample_rate"]`` in Hz (default 16000). Audio
+        is resampled to 16 kHz, flattened, and repeated or cropped to ten seconds.
+        Return ``multigauss_mos``, ``multigauss_noi``, ``multigauss_col``,
+        ``multigauss_dis``, and ``multigauss_loud`` without clipping; probabilistic
+        mode also returns ``multigauss_covariance`` in that order. References are
+        unused. Missing predictions raise ValueError; empty audio is unsupported."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -167,10 +176,12 @@ class MultiGaussMetric(BaseMetric):
         return multigauss_metric(self.model, np.asarray(predictions), fs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _multigauss_metadata()
 
 
 def _multigauss_metadata():
+    """Return registry metadata describing multigauss inputs and dependencies."""
     return MetricMetadata(
         name="multigauss",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/nisqa.py
+++ b/versa/utterance_metrics/nisqa.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 
 
 def _nisqa_lib():
+    """Return the bundled NISQA namespace or raise with dependency installation guidance."""
     if not NISQA_LIB_AVAILABLE and NL.NISQA is None and NL.versa_eval_mos is None:
         raise ImportError(
             "NISQA dependencies are not available. Please run tools/setup_nisqa.sh "

--- a/versa/utterance_metrics/noresqa.py
+++ b/versa/utterance_metrics/noresqa.py
@@ -171,6 +171,7 @@ class NoresqaMetric(BaseMetric):
         return model
 
     def _checkpoint_path(self, filename):
+        """Find a checkpoint in the configured or default cache, otherwise raise FileNotFoundError."""
         candidates = [
             os.path.join(self.cache_dir, filename),
             os.path.join(self.DEFAULT_CACHE_DIR, filename),

--- a/versa/utterance_metrics/noresqa_utils/noresqa_model.py
+++ b/versa/utterance_metrics/noresqa_utils/noresqa_model.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+"""Bundled NORESQA convolutional encoders and quality-prediction networks."""
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -19,6 +20,7 @@ import pickle
 
 
 class model_dimred(nn.Module):
+    """Combine four convolution/pooling branches and reduce the final feature axis."""
 
     def __init__(
         self,
@@ -31,6 +33,7 @@ class model_dimred(nn.Module):
         pool_proj=8,
         pool=2,
     ):
+        """Construct parallel 1x1, 3x3, 5x5, and pooled branches with output pooling."""
         super(model_dimred, self).__init__()
 
         self.modules1 = nn.ModuleList()
@@ -44,7 +47,7 @@ class model_dimred(nn.Module):
         self.modules1.append(nn.MaxPool2d((1, pool)))
 
     def forward(self, x):
-
+        """Concatenate activated branch outputs along channels and pool the last axis."""
         a = F.relu(self.modules1[0](x))
         b = F.relu(self.modules1[2]((F.relu(self.modules1[1](x)))))
         c = F.relu(self.modules1[4]((F.relu(self.modules1[3](x)))))
@@ -56,7 +59,10 @@ class model_dimred(nn.Module):
 
 
 class base_encoder(nn.Module):
+    """Encode magnitude/phase features through four dimension-reduction blocks."""
+
     def __init__(self, dev=torch.device("cpu")):
+        """Construct four feature blocks with final-axis pooling factors 4, 4, 4, and 2."""
         super(base_encoder, self).__init__()
         self.dev = dev
 
@@ -66,12 +72,16 @@ class base_encoder(nn.Module):
         self.modelD = model_dimred(in_channel=64, pool=2)
 
     def forward(self, x):
+        """Apply the four convolutional reduction blocks to batched spectral features."""
         x = self.modelD(self.modelC(self.modelB(self.modelA(x))))
         return x
 
 
 class which_clean(nn.Module):
+    """Predict frame-level clean-speech preference logits from paired embeddings."""
+
     def __init__(self):
+        """Construct three temporal convolution blocks ending in two preference channels."""
         super(which_clean, self).__init__()
         n_layers = 2
 
@@ -91,7 +101,7 @@ class which_clean(nn.Module):
         self.dp.append(nn.Dropout(p=dp_num))
 
     def forward(self, x):
-
+        """Return two-channel frame logits after convolution, normalization, and dropout."""
         for i in range(3):
             x = self.encoder[i](x)
             x = self.ebatch[i](x)

--- a/versa/utterance_metrics/noresqa_utils/noresqa_utils.py
+++ b/versa/utterance_metrics/noresqa_utils/noresqa_utils.py
@@ -5,6 +5,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
+"""Bundled NORESQA waveform preparation and preference inference helpers."""
 import torch
 import argparse
 import librosa as librosa
@@ -55,7 +56,9 @@ def argument_parser():
 
 # function extraction stft
 def extract_stft(audio, sampling_rate=16000):
+    """Return 256-bin frequency/time/magnitude-phase features from mono audio.
 
+    Use a 512-sample Hann window with 256-sample overlap; sampling_rate is Hz."""
     fx, tx, stft_out = signal.stft(
         audio, sampling_rate, window="hann", nperseg=512, noverlap=256, nfft=512
     )
@@ -72,7 +75,10 @@ def extract_stft(audio, sampling_rate=16000):
 
 # noresqa and noresqa-mos prediction calls
 def model_prediction_noresqa(test_feat, nmr_feat, model):
+    """Return cleaner-speech probability and expected SDR-bin score for one pair.
 
+    Inputs have batch/frequency/time/feature axes. Permute for the model,
+    apply softmax, and average frame predictions without tracking gradients."""
     intervals_sdr = np.arange(0.5, 40, 1)
 
     with torch.no_grad():
@@ -91,7 +97,10 @@ def model_prediction_noresqa(test_feat, nmr_feat, model):
 
 
 def model_prediction_noresqa_mos(test_feat, nmr_feat, model):
+    """Return the first raw NORESQA-MOS model output as a NumPy value.
 
+    Pass the nonmatching reference before test features; no MOS inversion
+    or clipping is applied here."""
     with torch.no_grad():
         score = model(nmr_feat, test_feat).detach().cpu().numpy()[0]
 
@@ -100,7 +109,7 @@ def model_prediction_noresqa_mos(test_feat, nmr_feat, model):
 
 # reading audio clips
 def audio_loading(path, sampling_rate=16000):
-
+    """Read mono audio from a file and resample to sampling_rate Hz when needed."""
     audio, fs = librosa.load(path, sr=None)
     if len(audio.shape) > 1:
         audio = librosa.to_mono(audio)
@@ -113,7 +122,10 @@ def audio_loading(path, sampling_rate=16000):
 
 # function checking if the size of the inputs are same. If not, then the reference audio's size is adjusted
 def check_size(audio_ref, audio_test):
+    """Repeat or truncate the nonempty reference to the test length, returning both.
 
+    The test waveform is unchanged; print a message when durations differ.
+    An empty reference cannot be repeated and is unsupported."""
     if len(audio_ref) > len(audio_test):
         print("Durations dont match. Adjusting duration of reference.")
         audio_ref = audio_ref[: len(audio_test)]
@@ -129,7 +141,11 @@ def check_size(audio_ref, audio_test):
 
 # audio loading and feature extraction
 def feats_loading(test_path, ref_path=None, noresqa_or_noresqaMOS=0):
+    """Prepare paired waveform arrays despite the legacy path parameter names.
 
+    Match reference duration to test duration. Mode 0 returns reference/test
+    STFT features, mode 1 returns the adjusted waveforms, and other modes
+    return None. Input audio must already be sampled at 16 kHz."""
     if noresqa_or_noresqaMOS == 0 or noresqa_or_noresqaMOS == 1:
 
         # audio_ref = audio_loading(ref_path)

--- a/versa/utterance_metrics/noresqa_utils/noresqa_utils.py
+++ b/versa/utterance_metrics/noresqa_utils/noresqa_utils.py
@@ -125,7 +125,9 @@ def check_size(audio_ref, audio_test):
     """Repeat or truncate the nonempty reference to the test length, returning both.
 
     The test waveform is unchanged; print a message when durations differ.
-    An empty reference cannot be repeated and is unsupported."""
+    Raise ValueError for an empty reference, which cannot be repeated."""
+    if len(audio_ref) == 0:
+        raise ValueError("NORESQA requires non-empty reference audio")
     if len(audio_ref) > len(audio_test):
         print("Durations dont match. Adjusting duration of reference.")
         audio_ref = audio_ref[: len(audio_test)]

--- a/versa/utterance_metrics/pam.py
+++ b/versa/utterance_metrics/pam.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+"""Text-audio contrastive perceptual audio quality scoring."""
 from __future__ import annotations
 
 import warnings

--- a/versa/utterance_metrics/pseudo_mos.py
+++ b/versa/utterance_metrics/pseudo_mos.py
@@ -7,6 +7,7 @@
 
 # flake8: noqa: E501
 
+"""Configurable speech and singing MOS predictors with model caching."""
 import logging
 import librosa
 import numpy as np
@@ -35,6 +36,11 @@ def pseudo_mos_setup(
 ):
     # Supported predictor types: utmos, dnsmos, aecmos, plcmos
     # Predictor args: predictor specific args
+    """Return predictor and sample-rate maps for the requested MOS backends.
+
+    Load or download models into their configured caches and select CPU/CUDA.
+    Torch Hub backends change the global Hub cache. Unknown predictor names
+    raise NotImplementedError; unavailable optional packages raise errors."""
     predictor_dict = {}
     predictor_fs = {}
     if use_gpu:
@@ -137,6 +143,11 @@ def pseudo_mos_setup(
 
 
 def pseudo_mos_metric(pred, fs, predictor_dict, predictor_fs, use_gpu=False):
+    """Run selected MOS predictors on mono audio sampled at fs Hz.
+
+    Return backend-specific keys, including dns_overall/dns_p808 for DNSMOS.
+    Each backend applies its preprocessing and output scale; scores are not
+    clipped. UTMOSv2 predictions are averaged over five inference passes."""
     scores = {}
     for predictor in predictor_dict.keys():
         if predictor == "utmos":
@@ -243,6 +254,10 @@ def pseudo_mos_metric(pred, fs, predictor_dict, predictor_fs, use_gpu=False):
                 use_magnitude: bool = True,
                 n_mels: Optional[int] = None,
             ) -> np.ndarray:
+                """Return time-major spectral features, optionally mel, magnitude, or log10.
+
+                Reject logarithmic complex output; clip magnitudes before taking the log.
+                """
                 if use_log and not use_magnitude:
                     raise ValueError(
                         "Log is only available if the magnitude is to be computed."
@@ -284,6 +299,7 @@ class PseudoMosMetric(BaseMetric):
     """Pseudo-subjective MOS predictors."""
 
     def _setup(self):
+        """Initialize the configured predictor collection and its model caches."""
         self.predictor_types = self.config.get(
             "predictor_types", ["utmos", "dnsmos", "plcmos"]
         )
@@ -298,6 +314,11 @@ class PseudoMosMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return selected backend MOS estimates for mono prediction audio.
+
+        ``metadata["sample_rate"]`` supplies Hz (default 16000). References are
+        unused, and channel mixing is not performed. Keys and scaling follow
+        ``pseudo_mos_metric``; missing predictions raise ValueError."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -311,10 +332,12 @@ class PseudoMosMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _pseudo_mos_metadata()
 
 
 def _pseudo_mos_metadata():
+    """Return registry metadata describing pseudo mos inputs and dependencies."""
     return MetricMetadata(
         name="pseudo_mos",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/pysepm.py
+++ b/versa/utterance_metrics/pysepm.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Psychoacoustic speech-enhancement metrics from the optional pysepm backend."""
 import logging
 
 import numpy as np
@@ -20,6 +21,7 @@ except ImportError:
 
 
 def is_pysepm_available():
+    """Return whether the optional pysepm package was imported successfully."""
     return pysepm is not None
 
 
@@ -175,6 +177,11 @@ def ncm(pred_x, gt_x, fs):
 
 
 def pysepm_metric(pred_x, gt_x, fs, frame_len=0.03, overlap=0.75):
+    """Return eleven ``pysepm_`` measurements for aligned mono prediction/reference audio.
+
+    fs is in Hz; frame_len is seconds and overlap is a fraction. Composite
+    and NCM scores use resampled 8 or 16 kHz audio; other metrics use fs.
+    Distances, ratios, and quality scores retain their distinct backend scales."""
     if pysepm is None:
         raise ImportError(
             "pysepm is not installed. Please use `tools/install_pysepm.sh` to install"
@@ -224,6 +231,7 @@ class PysepmMetric(BaseMetric):
     """Composite pysepm reference-based speech quality metrics."""
 
     def _setup(self):
+        """Require pysepm and retain frame duration and overlap settings."""
         if pysepm is None:
             raise ImportError(
                 "pysepm is not installed. "
@@ -233,6 +241,11 @@ class PysepmMetric(BaseMetric):
         self.overlap = self.config.get("overlap", 0.75)
 
     def compute(self, predictions, references=None, metadata=None):
+        """Compute the pysepm metric bundle for required aligned mono waveforms.
+
+        Use ``metadata["sample_rate"]`` in Hz (default 16000); no channel mixing
+        or length alignment is performed. Keys and preprocessing follow
+        ``pysepm_metric``. Missing either waveform raises ValueError."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -247,10 +260,12 @@ class PysepmMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _pysepm_metadata()
 
 
 def _pysepm_metadata():
+    """Return registry metadata describing pysepm inputs and dependencies."""
     return MetricMetadata(
         name="pysepm",
         category=MetricCategory.DEPENDENT,

--- a/versa/utterance_metrics/qwen2_audio.py
+++ b/versa/utterance_metrics/qwen2_audio.py
@@ -455,6 +455,9 @@ class Qwen2AudioMetric(BaseMetric):
     metric_name = None
 
     def _setup(self):
+        """Require a prompt metric name and load the configured Qwen2-Audio model/processor.
+
+        Model setup may download weights and tokenizer assets to the selected cache."""
         self.model_tag = self.config.get("model_tag", "default")
         self.start_prompt = self.config.get(
             "start_prompt",
@@ -476,6 +479,13 @@ class Qwen2AudioMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return the Qwen2-Audio response under ``qwen_<metric_name>``.
+
+        Provide mono audio with metadata sample_rate in Hz (default 16000).
+        Resample to the processor rate without channel mixing. References are
+        unused. Use the configured prompt or the default prompt for this metric.
+        Missing audio or an unavailable prompt raises ValueError. Responses are
+        decoded text strings, not normalized numeric quality scores."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -491,15 +501,21 @@ class Qwen2AudioMetric(BaseMetric):
         return {f"qwen_{self.metric_name}": response}
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _qwen2_audio_metadata(self.registry_name())
 
     @classmethod
     def registry_name(cls):
+        """Return the canonical Qwen2-Audio name for this class-level prompt metric."""
         return f"qwen2_audio_{cls.metric_name}" if cls.metric_name else "qwen2_audio"
 
 
 def _make_qwen2_metric_class(metric_name):
+    """Create a named Qwen2-Audio subclass bound to one default prompt identifier."""
+
     class _SpecificQwen2AudioMetric(Qwen2AudioMetric):
+        """Bind a single prompt identifier to the shared Qwen2-Audio scoring behavior."""
+
         pass
 
     _SpecificQwen2AudioMetric.metric_name = metric_name

--- a/versa/utterance_metrics/qwen_omni.py
+++ b/versa/utterance_metrics/qwen_omni.py
@@ -9,7 +9,7 @@
 Speech Properties for Metadata Modeling
 
 This module provides functions for extracting various speech properties
-from audio using Qwen2-Audio. The properties are organized into the
+from audio using Qwen2.5-Omni. The properties are organized into the
 following categories:
 
 1. Speaker Characteristics
@@ -55,8 +55,8 @@ Each function follows the same signature pattern:
     - qwen_omni_singing_technique_metric: Singing Techniques (styles)
 
 Each function returns a dictionary with a single key-value pair where
-the key is the metric name prefixed with "qwen_" and the value is the
-model's response.
+the key is the metric name prefixed with "qwen_omni_" and the value is a
+list of decoded model responses.
 """
 
 import copy
@@ -88,11 +88,16 @@ def qwen_omni_model_setup(
     device_map: Optional[str] = None,
     cache_dir: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Set up the Qwen2-Audio model for speech analysis.
+    """Load Qwen2.5-Omni model and processor classes for speech analysis.
 
     Args:
-        model_tag: Model identifier for Qwen2-Audio, defaults to Qwen2-Audio-7B-Instruct
+        model_tag: Checkpoint identifier. Pass "default" to select
+            Qwen/Qwen2.5-Omni-7B, as the metric wrapper does. The legacy
+            direct-call default still names a Qwen2-Audio checkpoint.
         start_prompt: Initial system prompt for the model conversation
+        use_gpu: Prefer CUDA when available, otherwise use CPU.
+        device_map: Explicit model placement, overriding the inferred device.
+        cache_dir: Optional Hugging Face download cache for model assets.
 
     Returns:
         Dictionary containing model, processor, and conversation starter
@@ -143,7 +148,8 @@ def qwen_omni_base_metric(
         max_length: Maximum length for model generation
 
     Returns:
-        Model's response as a string
+        List of decoded text responses from the processor. The legacy return
+        annotation says str, but batch_decode returns a list.
     """
     if custom_prompt is None:
         raise ValueError("Custom prompt must be provided for the qwen_omni model.")
@@ -268,6 +274,9 @@ class QwenOmniMetric(BaseMetric):
     metric_name = None
 
     def _setup(self):
+        """Require a prompt metric name and load the configured Qwen2.5-Omni model/processor.
+
+        Model setup may download weights and tokenizer assets to the selected cache."""
         self.model_tag = self.config.get("model_tag", "default")
         self.start_prompt = self.config.get(
             "start_prompt",
@@ -293,6 +302,13 @@ class QwenOmniMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return the Qwen2.5-Omni response under ``qwen_omni_<metric_name>``.
+
+        Provide mono audio with metadata sample_rate in Hz (default 16000).
+        Resample to the processor rate without channel mixing. References are
+        unused. Use the configured prompt or the default prompt for this metric.
+        Missing audio or an unavailable prompt raises ValueError. Responses are
+        lists of decoded text strings, not normalized numeric quality scores."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -308,15 +324,21 @@ class QwenOmniMetric(BaseMetric):
         return {f"qwen_omni_{self.metric_name}": response}
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _qwen_omni_metadata(self.registry_name())
 
     @classmethod
     def registry_name(cls):
+        """Return the canonical Qwen2.5-Omni name for this class-level prompt metric."""
         return f"qwen_omni_{cls.metric_name}" if cls.metric_name else "qwen_omni"
 
 
 def _make_qwen_omni_metric_class(metric_name):
+    """Create a named Qwen2.5-Omni subclass bound to one default prompt identifier."""
+
     class _SpecificQwenOmniMetric(QwenOmniMetric):
+        """Bind a single prompt identifier to the shared Qwen2.5-Omni scoring behavior."""
+
         pass
 
     _SpecificQwenOmniMetric.metric_name = metric_name

--- a/versa/utterance_metrics/qwen_omni.py
+++ b/versa/utterance_metrics/qwen_omni.py
@@ -61,7 +61,7 @@ list of decoded model responses.
 
 import copy
 import logging
-from typing import Dict, Optional, Any
+from typing import Dict, List, Optional, Any
 
 import numpy as np
 import torch
@@ -136,7 +136,7 @@ def qwen_omni_base_metric(
     fs: int = 16000,
     custom_prompt: Optional[str] = None,
     max_length: int = 500,
-) -> str:
+) -> List[str]:
     """Calculate the base metric from Qwen2.5-Omni results.
 
     Args:
@@ -148,8 +148,7 @@ def qwen_omni_base_metric(
         max_length: Maximum length for model generation
 
     Returns:
-        List of decoded text responses from the processor. The legacy return
-        annotation says str, but batch_decode returns a list.
+        List of decoded text responses from the processor.
     """
     if custom_prompt is None:
         raise ValueError("Custom prompt must be provided for the qwen_omni model.")
@@ -205,7 +204,7 @@ def create_metric_fn(metric_name: str) -> callable:
         pred_x: np.ndarray,
         fs: int = 16000,
         custom_prompt: Optional[str] = None,
-    ) -> Dict[str, str]:
+    ) -> Dict[str, List[str]]:
         """Calculate the specified metric from Qwen2.5-Omni results.
 
         Args:

--- a/versa/utterance_metrics/scoreq.py
+++ b/versa/utterance_metrics/scoreq.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""ScoreQ reference-based and reference-free speech quality evaluation."""
 import logging
 import sys
 import ast
@@ -24,6 +25,10 @@ try:
     sys.modules.setdefault("fairseq.meters", fairseq_meters)
 
     def _legacy_fairseq_args_to_cfg(args):
+        """Convert flat legacy checkpoint arguments into OmegaConf sections.
+
+        Parse string-valued latent_temp literals and supply generation defaults
+        needed by the installed Fairseq checkpoint loader."""
         values = dict(vars(args))
         for key in ("latent_temp",):
             value = values.get(key)
@@ -38,6 +43,7 @@ try:
         generation.setdefault("print_alignment", None)
 
         def section(name, source_key=None):
+            """Copy legacy arguments into a named Fairseq component configuration."""
             data = dict(values)
             data["_name"] = values.get(source_key or name)
             return data
@@ -80,6 +86,7 @@ def scoreq_nr_setup(
     cache_dir="versa_cache/scoreq_pt-models",
     use_gpu=False,
 ):
+    """Load reference-free ScoreQ for a domain and device, using cache_dir for weights."""
     if use_gpu:
         device = "cuda"
     else:
@@ -100,6 +107,7 @@ def scoreq_ref_setup(
     cache_dir="./scoreq_pt-models",
     use_gpu=False,
 ):
+    """Load reference-based ScoreQ for a domain and device, using cache_dir for weights."""
     if use_gpu:
         device = "cuda"
     else:
@@ -117,6 +125,7 @@ def scoreq_ref_setup(
 
 def scoreq_nr(model, pred_x, fs):
     # NOTE(jiatong): current model only have 16k options
+    """Resample mono predictions from fs Hz to 16 kHz and return ``scoreq_nr``."""
     if fs != 16000:
         pred_x = resample_audio(pred_x, fs, 16000)
 
@@ -125,6 +134,7 @@ def scoreq_nr(model, pred_x, fs):
 
 def scoreq_ref(model, pred_x, gt_x, fs):
     # NOTE(jiatong): current model only have 16k options
+    """Resample a mono prediction/reference pair to 16 kHz and return ``scoreq_ref``."""
     if fs != 16000:
         gt_x = resample_audio(gt_x, fs, 16000)
         pred_x = resample_audio(pred_x, fs, 16000)
@@ -136,6 +146,7 @@ class ScoreqMetric(BaseMetric):
     """ScoreQ speech quality metric."""
 
     def _setup(self):
+        """Validate the ScoreQ mode and load its model using the configured cache/device."""
         self.mode = self.config.get("mode", "nr")
         if self.mode not in {"nr", "ref"}:
             raise ValueError(f"Invalid ScoreQ mode: {self.mode}")
@@ -160,6 +171,12 @@ class ScoreqMetric(BaseMetric):
             )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return a ScoreQ prediction under ``scoreq_nr`` or ``scoreq_ref``.
+
+        Inputs are mono waveforms at ``metadata["sample_rate"]`` Hz (default
+        16000), resampled to 16 kHz without channel mixing or length alignment.
+        Reference mode requires both arrays; missing required audio raises
+        ValueError. The score is returned on the backend scale without clipping."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if self.mode == "ref" and references is None:
@@ -172,6 +189,7 @@ class ScoreqMetric(BaseMetric):
         return scoreq_nr(self.model, pred_x, fs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _scoreq_metadata(f"scoreq_{self.mode}", self.mode)
 
 
@@ -179,6 +197,7 @@ class ScoreqNrMetric(ScoreqMetric):
     """Reference-less ScoreQ speech quality metric."""
 
     def _setup(self):
+        """Default to reference-free mode before loading the ScoreQ model."""
         self.config = {**self.config, "mode": self.config.get("mode", "nr")}
         super()._setup()
 
@@ -187,6 +206,7 @@ class ScoreqRefMetric(ScoreqMetric):
     """Reference-based ScoreQ speech quality metric."""
 
     def _setup(self):
+        """Default to reference-based mode before loading the ScoreQ model."""
         self.config = {**self.config, "mode": self.config.get("mode", "ref")}
         super()._setup()
 

--- a/versa/utterance_metrics/se_snr.py
+++ b/versa/utterance_metrics/se_snr.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Speech-enhancement-based signal quality estimation."""
 import numpy as np
 
 try:
@@ -21,6 +22,10 @@ def se_snr_setup(
     use_gpu=False,
     cache_dir=None,
 ):
+    """Load an ESPnet enhancer from local files or a downloadable model tag.
+
+    When cache_dir is supplied, model-zoo downloads are stored there. Return
+    a SeparateSpeech instance on CPU or CUDA; missing ESPnet raises ImportError."""
     if SeparateSpeech is None:
         raise ImportError("se_snr requires espnet. Please install espnet and retry")
 
@@ -59,6 +64,9 @@ def se_snr_setup(
 
 
 def se_snr(model, pred_x, fs):
+    """Enhance mono audio at fs Hz, then return signal metrics with ``se_`` prefixes.
+
+    The enhanced signal acts as the reference. SIR is omitted from the result."""
     enhanced_x = model(pred_x[None, :], fs=fs)[0]
     signal_metrics = signal_metric(pred_x, enhanced_x)
     updated_metrics = {f"se_{key}": value for key, value in signal_metrics.items()}
@@ -70,6 +78,7 @@ class SeSnrMetric(BaseMetric):
     """Speech enhancement-based signal quality metrics."""
 
     def _setup(self):
+        """Load the configured enhancement model, downloading into its cache if needed."""
         self.model_tag = self.config.get("model_tag", "default")
         self.model_path = self.config.get("model_path")
         self.model_config = self.config.get("model_config")
@@ -84,6 +93,11 @@ class SeSnrMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Estimate signal quality using an enhanced version of mono predictions.
+
+        ``metadata["sample_rate"]`` is in Hz and defaults to 16000. References are
+        unused; missing predictions raise ValueError. Return ``se_sdr``, ``se_sar``,
+        ``se_si_snr``, and ``se_ci_sdr`` in dB, without clipping or channel mixing."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -91,10 +105,12 @@ class SeSnrMetric(BaseMetric):
         return se_snr(self.model, np.asarray(predictions), fs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _se_snr_metadata()
 
 
 def _se_snr_metadata():
+    """Return registry metadata describing se snr inputs and dependencies."""
     return MetricMetadata(
         name="se_snr",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/sheet_ssqa.py
+++ b/versa/utterance_metrics/sheet_ssqa.py
@@ -5,6 +5,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Sheet SSQA model loading and MOS estimation."""
 import numpy as np
 import time
 import torch
@@ -21,6 +22,10 @@ def sheet_ssqa_setup(
     cache_dir="versa_cache",
     use_gpu=False,
 ):
+    """Load a Sheet model through Torch Hub and move it to the selected device.
+
+    Set the global Hub cache directory and retry network errors up to three
+    times. Supplying both local model files raises NotImplementedError."""
     if use_gpu:
         device = "cuda"
     else:
@@ -51,6 +56,7 @@ def sheet_ssqa_setup(
 
 def sheet_ssqa(model, pred_x, fs, use_gpu=False):
     # NOTE(jiatong): current model only work for 16000 Hz
+    """Resample mono audio from fs Hz to 16 kHz and return the model score as ``sheet_ssqa``."""
     if fs != 16000:
         pred_x = resample_audio(pred_x, fs, 16000)
     pred_x = torch.tensor(pred_x).float()
@@ -63,6 +69,7 @@ class SheetSsqaMetric(BaseMetric):
     """Sheet SSQA MOS prediction metric."""
 
     def _setup(self):
+        """Load the configured Sheet Hub model, downloading into cache_dir if needed."""
         self.model_tag = self.config.get("model_tag", "default")
         self.model_path = self.config.get("model_path")
         self.model_config = self.config.get("model_config")
@@ -77,6 +84,11 @@ class SheetSsqaMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return the backend MOS estimate under ``sheet_ssqa`` for mono predictions.
+
+        The sample rate comes from metadata in Hz (default 16000); audio is
+        resampled to 16 kHz. References are unused and no channel mixing is done.
+        The backend value is not clipped; absent predictions raise ValueError."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -84,10 +96,12 @@ class SheetSsqaMetric(BaseMetric):
         return sheet_ssqa(self.model, np.asarray(predictions), fs, use_gpu=self.use_gpu)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _sheet_ssqa_metadata()
 
 
 def _sheet_ssqa_metadata():
+    """Return registry metadata describing sheet ssqa inputs and dependencies."""
     return MetricMetadata(
         name="sheet_ssqa",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/sigmos.py
+++ b/versa/utterance_metrics/sigmos.py
@@ -1,3 +1,5 @@
+"""SIG-MOS ONNX inference for speech quality dimensions."""
+
 import os
 import logging
 from enum import Enum
@@ -18,6 +20,8 @@ SIGMOS_MODEL_URL = (
 
 
 class Version(Enum):
+    """Identify the supported SIG-MOS checkpoint revisions."""
+
     V1 = "v1"  # 15.10.2023
 
 
@@ -29,6 +33,7 @@ class SigMOS:
     """
 
     def __init__(self, model_dir, model_version=Version.V1):
+        """Load the selected ONNX checkpoint and configure 48 kHz STFT preprocessing."""
         assert model_version in [v for v in Version]
 
         model_path_history = {
@@ -53,6 +58,7 @@ class SigMOS:
         self.session = ort.InferenceSession(model_path_history[model_version], options)
 
     def stft(self, signal):
+        """Pad mono audio and return time-major complex64 windowed real-FFT frames."""
         last_frame = len(signal) % self.frame_size
         if last_frame == 0:
             last_frame = self.frame_size
@@ -72,6 +78,7 @@ class SigMOS:
 
     @staticmethod
     def compressed_mag_complex(x: np.ndarray, compress_factor=0.3):
+        """Build batched compressed magnitude, real, and imaginary features for ONNX."""
         x = x.view(np.float32).reshape(x.shape + (2,)).swapaxes(-1, -2)
         x2 = np.maximum((x * x).sum(axis=-2, keepdims=True), 1e-12)
         if compress_factor == 1:
@@ -85,6 +92,11 @@ class SigMOS:
         return np.expand_dims(features, 0)
 
     def run(self, audio: np.ndarray, sr=None):
+        """Return six SIGMOS quality dimensions after optional resampling to 48 kHz.
+
+        Input is mono audio. sr is in Hz; None means audio is already at 48 kHz.
+        Output keys are SIGMOS_COL, SIGMOS_DISC, SIGMOS_LOUD, SIGMOS_REVERB,
+        SIGMOS_SIG, and SIGMOS_OVRL; backend values are returned without clipping."""
         if sr is not None and sr != self.sampling_rate:
             audio = librosa.resample(
                 audio,
@@ -112,7 +124,7 @@ class SigMOS:
 
 
 def sigmos_setup(model_dir=None):
-
+    """Create the model directory, download an absent ONNX checkpoint, and load SIG-MOS."""
     if model_dir is None:
         # Get the absolute path to the current file (this script)
         script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -163,19 +175,27 @@ class SigmosMetric(BaseMetric):
     """SIG-MOS metric using the ICASSP 2024 SIG Challenge ONNX model."""
 
     def _setup(self):
+        """Load SIG-MOS from model_dir or cache_dir, downloading an absent checkpoint."""
         model_dir = self.config.get("model_dir", self.config.get("cache_dir"))
         self.model = sigmos_setup(model_dir=model_dir)
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return the six quality dimensions documented by ``SigMOS.run`` for mono audio.
+
+        Read sample_rate in Hz from metadata (default 48000); the model resamples
+        to 48 kHz. References are unused and no channel mixing is performed.
+        Backend errors propagate; this wrapper does not add input validation."""
         metadata = metadata or {}
         sample_rate = metadata.get("sample_rate", 48000)
         return sigmos_calculate(self.model, predictions, sample_rate)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _sigmos_metadata()
 
 
 def _sigmos_metadata():
+    """Return registry metadata describing sigmos inputs and dependencies."""
     return MetricMetadata(
         name="sigmos",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/singer.py
+++ b/versa/utterance_metrics/singer.py
@@ -3,6 +3,7 @@
 # Adapted from speaker similarity code for singer identity
 # Uses SSL singer identity models from SonyCSLParis/ssl-singer-identity
 
+"""Singer identity model loading and paired embedding comparison."""
 import logging
 
 import numpy as np
@@ -183,6 +184,7 @@ class SingerMetric(BaseMetric):
     """Singer identity embedding cosine similarity."""
 
     def _setup(self):
+        """Load the selected singer encoder with its cache, device, and input-rate settings."""
         self.model_name = self.config.get("model_name", "byol")
         self.model_path = self.config.get("model_path")
         self.use_gpu = self.config.get("use_gpu", False)
@@ -200,6 +202,12 @@ class SingerMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ``singer_similarity`` cosine similarity for required mono audio pairs.
+
+        Read their common sample rate from metadata in Hz (default 16000), then
+        resample to target_sr (default 44100). No channel mixing or time alignment
+        is performed. Larger cosine similarity means closer embeddings; zero-norm
+        embeddings are not specially handled. Missing either input raises ValueError."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -215,10 +223,12 @@ class SingerMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _singer_metadata()
 
 
 def _singer_metadata():
+    """Return registry metadata describing singer inputs and dependencies."""
     return MetricMetadata(
         name="singer",
         category=MetricCategory.NON_MATCH,

--- a/versa/utterance_metrics/songeval.py
+++ b/versa/utterance_metrics/songeval.py
@@ -1,3 +1,5 @@
+"""SongEval aesthetics inference with local or cached model assets."""
+
 import importlib.util
 import hashlib
 import logging
@@ -44,6 +46,7 @@ SONGEVAL_OUTPUTS = (
 
 
 def _require_songeval_dependencies():
+    """Raise ImportError listing unavailable SongEval inference dependencies."""
     missing = []
     if MuQ is None:
         missing.append("muq")
@@ -60,6 +63,7 @@ def _require_songeval_dependencies():
 
 
 def _required_songeval_files(songeval_dir):
+    """Return the code, configuration, and checkpoint paths required by SongEval."""
     return (
         songeval_dir / "model.py",
         songeval_dir / "config.yaml",
@@ -68,6 +72,10 @@ def _required_songeval_files(songeval_dir):
 
 
 def _resolve_songeval_dir(cache_dir, model_dir=None, offline=False):
+    """Locate complete SongEval assets, optionally cloning the pinned revision.
+
+    Only clone when the default cache checkout is absent and offline is false.
+    Never repair an existing incomplete checkout; report missing files instead."""
     songeval_dir = Path(model_dir) if model_dir else Path(cache_dir) / "SongEval"
     missing_files = [
         str(path)
@@ -256,6 +264,7 @@ class SongEvalMetric(BaseMetric):
     """SongEval song aesthetics predictor."""
 
     def _setup(self):
+        """Load SongEval and MuQ, honoring explicit asset paths and offline mode."""
         self.cache_dir = self.config.get("cache_dir", "versa_cache")
         self.use_gpu = self.config.get("use_gpu", False)
         self.model_dir = self.config.get("model_dir")
@@ -270,6 +279,15 @@ class SongEvalMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return five SongEval aesthetics scores for prediction audio.
+
+        Use ``metadata["sample_rate"]`` in Hz (default 24000). Accept mono or
+        2D audio with at most eight channels, average channels, and resample to
+        24 kHz. Return songeval_coherence, songeval_musicality, songeval_memorability,
+        songeval_clarity, and songeval_naturalness, rounded to four decimals without
+        clipping. References are unused. Invalid rates, empty/nonfinite audio, or
+        ambiguous shapes raise ValueError; malformed model output raises RuntimeError.
+        """
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -277,10 +295,12 @@ class SongEvalMetric(BaseMetric):
         return songeval_metric(self.model_dict, np.asarray(predictions), fs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _songeval_metadata()
 
 
 def _songeval_metadata():
+    """Return registry metadata describing songeval inputs and dependencies."""
     return MetricMetadata(
         name="songeval",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/speaker.py
+++ b/versa/utterance_metrics/speaker.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Speaker embedding extraction and paired cosine-similarity scoring."""
 import logging
 
 import numpy as np
@@ -78,6 +79,10 @@ def speaker_model_setup(
     use_gpu=False,
     cache_dir=None,
 ):
+    """Load ESPnet speaker embeddings from local files or a pretrained tag.
+
+    Select CPU/CUDA and optionally download model-zoo assets into cache_dir.
+    Missing ESPnet or a required downloader raises ImportError."""
     if Speech2Embedding is None:
         raise ImportError("speaker requires espnet. Please install espnet and retry")
 
@@ -116,11 +121,13 @@ class HFSpeakerModel:
     """
 
     def __init__(self, model, feature_extractor, device):
+        """Bind the pretrained embedding model, feature extractor, and target device."""
         self.model = model
         self.feature_extractor = feature_extractor
         self.device = device
 
     def __call__(self, speech):
+        """Extract embeddings from 16 kHz speech under torch.no_grad on the target device."""
         inputs = self.feature_extractor(
             speech, sampling_rate=16000, return_tensors="pt"
         )
@@ -165,6 +172,10 @@ def hf_speaker_model_setup(
 
 def speaker_metric(model, pred_x, gt_x, fs):
     # NOTE(jiatong): only work for 16000 Hz
+    """Return ``spk_similarity`` cosine similarity after resampling mono pairs to 16 kHz.
+
+    fs is the shared input rate in Hz. Warn on upsampling; no channel mixing
+    or zero-norm protection is applied to the embeddings."""
     if fs < 16000:
         logger.warning(
             "Speaker similarity with sampling rates below 16 kHz may be unreliable "
@@ -194,6 +205,7 @@ class SpeakerMetric(BaseMetric):
     """
 
     def _setup(self):
+        """Resolve the ESPnet or Hugging Face backend and load its cached speaker model."""
         self.model_tag = self.config.get("model_tag", "default")
         self.model_path = self.config.get("model_path")
         self.model_config = self.config.get("model_config")
@@ -224,6 +236,12 @@ class SpeakerMetric(BaseMetric):
             )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ``spk_similarity`` for required mono prediction and reference audio.
+
+        Use their shared ``metadata["sample_rate"]`` in Hz (default 16000). Both
+        are resampled to 16 kHz; no channel mixing or time alignment is performed.
+        Higher cosine similarity indicates closer embeddings. Missing either input
+        raises ValueError; backend and numerical failures are not suppressed."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -235,10 +253,12 @@ class SpeakerMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _speaker_metadata()
 
 
 def _speaker_metadata():
+    """Return registry metadata describing speaker inputs and dependencies."""
     return MetricMetadata(
         name="speaker",
         category=MetricCategory.NON_MATCH,

--- a/versa/utterance_metrics/speaking_rate.py
+++ b/versa/utterance_metrics/speaking_rate.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Whisper transcription and word or character rate estimation."""
 import logging
 
 import numpy as np
@@ -39,6 +40,10 @@ def speaking_rate_model_setup(
     use_gpu=True,
     cache_dir="versa_cache/whisper",
 ):
+    """Load Whisper and an ESPnet text cleaner, caching model weights under cache_dir.
+
+    Return model, cleaner, and beam_size entries. The default model tag is large;
+    missing Whisper or TextCleaner raises ImportError."""
     if model_tag == "default":
         model_tag = "large"
     device = "cuda" if use_gpu else "cpu"
@@ -96,6 +101,7 @@ class SpeakingRateMetric(BaseMetric):
     """Speaking word or character rate estimated from Whisper ASR output."""
 
     def _setup(self):
+        """Initialize Whisper and retain decoding, cache, and character-count settings."""
         self.model_tag = self.config.get("model_tag", "default")
         self.beam_size = self.config.get("beam_size", 5)
         self.text_cleaner = self.config.get("text_cleaner", "whisper_basic")
@@ -111,6 +117,13 @@ class SpeakingRateMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return speaking rate per second and ``whisper_hyp_text`` for mono audio.
+
+        Count words by default or characters with use_char. Read sample_rate
+        from metadata in Hz (default 16000); decode resampled 16 kHz audio unless
+        whisper_hyp_text is available in metadata or general_cache. References
+        are unused. Missing audio raises ValueError; empty audio is unsupported.
+        Speaking rate has no universal better direction."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -131,10 +144,12 @@ class SpeakingRateMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _speaking_rate_metadata()
 
 
 def _speaking_rate_metadata():
+    """Return registry metadata describing speaking rate inputs and dependencies."""
     return MetricMetadata(
         name="speaking_rate",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/squim.py
+++ b/versa/utterance_metrics/squim.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""TorchAudio SQUIM objective and subjective speech quality models."""
 import logging
 
 import numpy as np
@@ -26,6 +27,7 @@ SQUIM_AVAILABLE = SQUIM_OBJECTIVE is not None and SQUIM_SUBJECTIVE is not None
 
 
 def is_squim_available():
+    """Return whether SQUIM and its required metric dependencies were imported."""
     return SQUIM_AVAILABLE
 
 
@@ -81,6 +83,7 @@ class SquimMetric(BaseMetric):
     """TorchAudio-SQUIM speech quality metric."""
 
     def _setup(self):
+        """Validate mode, set the global Torch Hub cache, and load a SQUIM model."""
         if not SQUIM_AVAILABLE:
             raise ImportError(
                 "SQUIM is not available. Please install pesq, pystoi, and torchaudio"
@@ -96,6 +99,13 @@ class SquimMetric(BaseMetric):
             self.model = SQUIM_OBJECTIVE.get_model()
 
     def compute(self, predictions, references=None, metadata=None):
+        """Predict SQUIM speech quality from mono waveform arrays.
+
+        Read sample_rate in Hz from metadata (default 16000), resample to 16 kHz,
+        and add a batch axis without mixing channels. Ref mode requires a second
+        waveform and returns torch_squim_mos; no_ref mode returns torch_squim_stoi,
+        torch_squim_pesq, and torch_squim_si_sdr. Missing required audio raises
+        ValueError. Estimates retain backend scaling without clipping."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if self.mode == "ref" and references is None:
@@ -123,6 +133,7 @@ class SquimMetric(BaseMetric):
         }
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _squim_metadata(f"squim_{self.mode}", self.mode)
 
 
@@ -130,6 +141,7 @@ class SquimRefMetric(SquimMetric):
     """Reference-based TorchAudio-SQUIM MOS metric."""
 
     def _setup(self):
+        """Default to subjective reference mode before loading the SQUIM model."""
         self.config = {**self.config, "mode": self.config.get("mode", "ref")}
         super()._setup()
 
@@ -138,6 +150,7 @@ class SquimNoRefMetric(SquimMetric):
     """Reference-less TorchAudio-SQUIM objective metrics."""
 
     def _setup(self):
+        """Default to objective reference-free mode before loading the SQUIM model."""
         self.config = {**self.config, "mode": self.config.get("mode", "no_ref")}
         super()._setup()
 

--- a/versa/utterance_metrics/srmr.py
+++ b/versa/utterance_metrics/srmr.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Speech-to-reverberation modulation energy ratio scoring."""
 import logging
 from typing import Dict, Any, Optional
 

--- a/versa/utterance_metrics/stoi.py
+++ b/versa/utterance_metrics/stoi.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Standard and extended short-time objective intelligibility scoring."""
 import numpy as np
 
 try:
@@ -14,6 +15,7 @@ from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricT
 
 
 def stoi_metric(pred_x, gt_x, fs):
+    """Return ``stoi`` for mono arrays at fs Hz, trimming both to the shorter length."""
     if pred_x.shape[0] != gt_x.shape[0]:
         min_length = min(pred_x.shape[0], gt_x.shape[0])
         pred_x = pred_x[:min_length]
@@ -23,6 +25,7 @@ def stoi_metric(pred_x, gt_x, fs):
 
 
 def estoi_metric(pred_x, gt_x, fs):
+    """Return ``estoi`` for mono arrays at fs Hz, trimming both to the shorter length."""
     if pred_x.shape[0] != gt_x.shape[0]:
         min_length = min(pred_x.shape[0], gt_x.shape[0])
         pred_x = pred_x[:min_length]
@@ -35,10 +38,18 @@ class StoiMetric(BaseMetric):
     """Short-Time Objective Intelligibility metric."""
 
     def _setup(self):
+        """Select standard or extended STOI and its corresponding result key."""
         self.extended = self.config.get("extended", False)
         self.output_key = "estoi" if self.extended else "stoi"
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ``stoi`` or ``estoi`` intelligibility for a pair of mono waveforms.
+
+        Both arrays are required and truncated to their shared minimum length.
+        ``metadata["sample_rate"]`` supplies Hz, defaulting to 16000. No channel
+        mixing is performed. Larger scores indicate greater intelligibility;
+        the backend score is returned without clipping. Missing audio raises
+        ValueError; other input restrictions are enforced by pystoi."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -53,6 +64,7 @@ class StoiMetric(BaseMetric):
         return stoi_metric(pred_x, gt_x, fs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _stoi_metadata(self.output_key, self.extended)
 
 
@@ -60,11 +72,13 @@ class EstoiMetric(StoiMetric):
     """Extended Short-Time Objective Intelligibility metric."""
 
     def _setup(self):
+        """Default to extended STOI unless the configuration explicitly disables it."""
         self.extended = self.config.get("extended", True)
         self.output_key = "estoi" if self.extended else "stoi"
 
 
 def _stoi_metadata(name, extended):
+    """Return registry metadata describing stoi inputs and dependencies."""
     label = "ESTOI" if extended else "STOI"
     description = (
         "Extended Short-Time Objective Intelligibility"

--- a/versa/utterance_metrics/universa.py
+++ b/versa/utterance_metrics/universa.py
@@ -4,6 +4,7 @@
 # Mainly adapted from ESPnet-SE (https://github.com/espnet/espnet.git)
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Uni-VERSA speech evaluation with optional audio and text references."""
 import numpy as np
 import torch
 import soundfile
@@ -12,6 +13,7 @@ from versa.audio_utils import resample_audio
 
 
 def _ensure_torchaudio_legacy_backend_api():
+    """Supply the removed no-op backend setter needed by legacy ESPnet imports."""
     try:
         import torchaudio
     except ImportError:
@@ -312,6 +314,7 @@ class UniversaMetric(BaseMetric):
     """Uni-VERSA speech assessment metric."""
 
     def _setup(self):
+        """Retain reference mode and cache settings, deferring model loading to compute."""
         self.model_type = self.config.get(
             "model_type", self.config.get("model_tag", "auto")
         )
@@ -320,6 +323,17 @@ class UniversaMetric(BaseMetric):
         self.cache_dir = self.config.get("cache_dir")
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return Uni-VERSA quality estimates using the configured reference mode.
+
+        Predictions are a path or mono/sample-by-channel NumPy array. Audio is
+        downmixed and resampled to 16 kHz. Metadata supplies sample_rate (default
+        16000 Hz), reference_sample_rate (default the prediction rate), and text.
+        A string in references is interpreted as text, not an audio path.
+
+        Auto mode selects a model from available references; explicit modes raise
+        ValueError when required inputs are absent. Models are lazily loaded and
+        cached and may download assets. Return backend dimensions with universa_
+        prefixes and backend scaling, without clipping."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -373,10 +387,12 @@ class UniversaMetric(BaseMetric):
         return universa_metric(predictions, **metric_kwargs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _universa_metadata()
 
 
 def _universa_metadata():
+    """Return registry metadata describing universa inputs and dependencies."""
     return MetricMetadata(
         name="universa",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/vad.py
+++ b/versa/utterance_metrics/vad.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""Silero voice activity detection and speech timestamp extraction."""
 import librosa
 import numpy as np
 import torch
@@ -21,6 +22,10 @@ def vad_model_setup(
     force_reload=False,
     cache_dir="versa_cache/torch",
 ):
+    """Load Silero VAD through Torch Hub and return its model, utility, and thresholds.
+
+    Set the global Hub cache to cache_dir; the call may download model assets.
+    Duration thresholds use the units specified in their parameter names."""
     torch.hub.set_dir(cache_dir)
     hub_kwargs = {
         "repo_or_dir": "snakers4/silero-vad",
@@ -43,6 +48,9 @@ def vad_model_setup(
 
 
 def vad_metric(model_info, pred_x, fs):
+    """Return ``vad_info`` speech start/end timestamps in seconds for mono audio.
+
+    Resample rates above 16 kHz to 16 kHz and rates below 16 kHz to 8 kHz."""
     model = model_info["module"]
     get_speech_ts = model_info["util"]
     # NOTE(jiatong): only work for 16000 Hz
@@ -71,6 +79,7 @@ class VadMetric(BaseMetric):
     """Voice activity detection using Silero VAD."""
 
     def _setup(self):
+        """Load the Silero model and retain configured speech segmentation thresholds."""
         self.threshold = self.config.get("threshold", 0.5)
         self.min_speech_duration_ms = self.config.get("min_speech_duration_ms", 250)
         self.max_speech_duration_s = self.config.get(
@@ -93,6 +102,12 @@ class VadMetric(BaseMetric):
         )
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return speech intervals in seconds under ``vad_info`` for mono predictions.
+
+        Read the input rate from metadata in Hz (default 16000). The backend
+        helper resamples to 8 or 16 kHz and performs no channel mixing. References
+        are unused; absent predictions raise ValueError. Timestamps are
+        segmentation results, not a quality score."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -100,10 +115,12 @@ class VadMetric(BaseMetric):
         return vad_metric(self.model_info, np.asarray(predictions), fs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _vad_metadata()
 
 
 def _vad_metadata():
+    """Return registry metadata describing vad inputs and dependencies."""
     return MetricMetadata(
         name="vad",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/visqol_score.py
+++ b/versa/utterance_metrics/visqol_score.py
@@ -3,6 +3,7 @@
 # Copyright 2024 Jiatong Shi
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""ViSQOL speech and audio quality evaluation against a reference."""
 import os
 
 import numpy as np
@@ -21,6 +22,10 @@ except ImportError:
 def visqol_setup(model):
     # model name related to
     # https://github.com/google/visqol/tree/master/model
+    """Create a ViSQOL API and return it with its required sample rate.
+
+    Speech mode uses 16 kHz; other supported models use 48 kHz. Model files
+    come from the installed package. Unknown tags raise NotImplementedError."""
     if visqol_lib_py is None or visqol_config_pb2 is None:
         raise ImportError(
             "visqol is not installed. Please install visqol following "
@@ -60,6 +65,7 @@ def visqol_setup(model):
 
 
 def visqol_metric(api, api_fs, pred_x, gt_x, fs):
+    """Resample paired mono audio from fs to api_fs Hz and return ``visqol`` MOS-LQO."""
     if api_fs != fs:
         gt_x = resample_audio(gt_x, fs, api_fs)
         pred_x = resample_audio(pred_x, fs, api_fs)
@@ -73,10 +79,17 @@ class VisqolMetric(BaseMetric):
     """Virtual Speech Quality Objective Listener metric."""
 
     def _setup(self):
+        """Create the selected installed ViSQOL model and retain its required sample rate."""
         self.model = self.config.get("model", "default")
         self.api, self.api_fs = visqol_setup(self.model)
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ``visqol`` MOS-LQO for required prediction and reference waveforms.
+
+        Provide mono audio with a shared ``metadata["sample_rate"]`` in Hz
+        (default 16000). Both are resampled to the model rate, without length
+        alignment or channel mixing. Larger MOS-LQO indicates better quality;
+        values are not clipped. Missing either waveform raises ValueError."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
         if references is None:
@@ -92,10 +105,12 @@ class VisqolMetric(BaseMetric):
         )
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _visqol_metadata()
 
 
 def _visqol_metadata():
+    """Return registry metadata describing visqol score inputs and dependencies."""
     return MetricMetadata(
         name="visqol",
         category=MetricCategory.DEPENDENT,

--- a/versa/utterance_metrics/vqscore.py
+++ b/versa/utterance_metrics/vqscore.py
@@ -3,6 +3,7 @@
 # Copyright 2025 Wangyou Zhang
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""VQScore spectral reconstruction similarity for speech quality."""
 import logging
 from pathlib import Path
 import sys
@@ -33,6 +34,10 @@ except ImportError:
 
 
 def vqscore_setup(use_gpu=False):
+    """Load the installed VQScore config and checkpoint on CPU or CUDA.
+
+    Enable cuDNN benchmarking for CUDA and retain the input transform on the
+    model. Missing VQScore raises ModuleNotFoundError with installer guidance."""
     if use_gpu:
         device = "cuda"
     else:
@@ -78,6 +83,7 @@ def vqscore_setup(use_gpu=False):
 
 # ported from VQscore/inference.py
 def stft_magnitude(x, hop_size, fft_size=512, win_length=512):
+    """Return batch/time/frequency STFT magnitudes with a floor before the square root."""
     if x.is_cuda:
         x_stft = torch.stft(
             x,
@@ -103,6 +109,7 @@ def stft_magnitude(x, hop_size, fft_size=512, win_length=512):
 
 
 def cos_similarity(SP_noisy, SP_y_noisy, eps=1e-5):
+    """Average cosine similarity over feature vectors, stabilizing norms with eps."""
     SP_noisy_norm = torch.norm(SP_noisy, p=2, dim=-1, keepdim=True) + eps
     SP_y_noisy_norm = torch.norm(SP_y_noisy, p=2, dim=-1, keepdim=True) + eps
     Cos_frame = torch.sum(
@@ -114,6 +121,7 @@ def cos_similarity(SP_noisy, SP_y_noisy, eps=1e-5):
 
 def vqscore_metric(model, pred_x, fs):
     # NOTE(wangyou): current model only have 16k options
+    """Resample mono audio from fs Hz to 16 kHz and return latent cosine ``vqscore``."""
     if fs != 16000:
         pred_x = resample_audio(pred_x, fs, 16000)
 
@@ -137,10 +145,16 @@ class VqscoreMetric(BaseMetric):
     """VQScore speech quality assessment metric."""
 
     def _setup(self):
+        """Load the local VQScore checkpoint on the configured device."""
         self.use_gpu = self.config.get("use_gpu", False)
         self.model = vqscore_setup(use_gpu=self.use_gpu)
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return ``vqscore`` similarity between encoded and quantized mono audio.
+
+        Read sample_rate in Hz from metadata (default 16000) and resample to
+        16 kHz without channel mixing. References are unused. The mean latent
+        cosine score is returned without clipping; missing audio raises ValueError."""
         if predictions is None:
             raise ValueError("Predicted signal must be provided")
 
@@ -148,10 +162,12 @@ class VqscoreMetric(BaseMetric):
         return vqscore_metric(self.model, np.asarray(predictions), fs)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _vqscore_metadata()
 
 
 def _vqscore_metadata():
+    """Return registry metadata describing vqscore inputs and dependencies."""
     return MetricMetadata(
         name="vqscore",
         category=MetricCategory.INDEPENDENT,

--- a/versa/utterance_metrics/wvmos.py
+++ b/versa/utterance_metrics/wvmos.py
@@ -2,6 +2,7 @@
 
 #  Apache 2.0  (http://www.apache.org/licenses/LICENSE-2.0)
 
+"""WV-MOS model loading and reference-free waveform scoring."""
 import logging
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,7 @@ from versa.definition import BaseMetric, MetricCategory, MetricMetadata, MetricT
 
 
 def wvmos_setup(use_gpu=False):
+    """Load the optional WV-MOS pretrained model on CPU or CUDA via its backend."""
     try:
         from wvmos import get_wvmos
     except ImportError as e:
@@ -51,19 +53,27 @@ class WvmosMetric(BaseMetric):
     """WV-MOS metric using a fine-tuned wav2vec2 model."""
 
     def _setup(self):
+        """Load the WV-MOS model on the configured device."""
         self.use_gpu = self.config.get("use_gpu", False)
         self.model = wvmos_setup(use_gpu=self.use_gpu)
 
     def compute(self, predictions, references=None, metadata=None):
+        """Return the backend mean MOS estimate under ``wvmos`` for mono audio.
+
+        Use ``metadata["sample_rate"]`` in Hz (default 16000) and resample to
+        16 kHz without channel mixing. References are unused. The wrapper does
+        not clip scores or add validation beyond the backend processing."""
         metadata = metadata or {}
         sample_rate = metadata.get("sample_rate", 16000)
         return wvmos_calculate(self.model, predictions, sample_rate)
 
     def get_metadata(self):
+        """Return input requirements and provenance for this metric configuration."""
         return _wvmos_metadata()
 
 
 def _wvmos_metadata():
+    """Return registry metadata describing wvmos inputs and dependencies."""
     return MetricMetadata(
         name="wvmos",
         category=MetricCategory.INDEPENDENT,


### PR DESCRIPTION
Recent automated reviews reported low docstring coverage in #93, #95, and #96. This PR documents metric inputs, outputs, errors, and model/cache behavior and enforces at least 80% package docstring coverage with three independent measurements.

## Changes

- Add 393 package docstrings, including 335 function docstrings, with contributor guidance and a checker survey in `docs/docstring_coverage.md`.
- Add pinned Interrogate and docstr-coverage checks and a function-only AST counter. All 78 Python files under `versa/` are included, including bundled implementations, private/nested functions, and constructors.
- Address review findings: validate reference keys before chunking, pass paired chunk directories with directory I/O to corpus scoring, reject empty resolved baseline collections in FAD/individual FAD/KID, and reject empty NORESQA references before repetition.
- Align ASR Match metadata with its dictionary output and Qwen Omni return annotations with decoded response lists.
- Align CI's Black version with pre-commit, restrict workflow permissions to read-only contents, and disable checkout credential persistence.

## Coverage

| Check | Before | After |
| --- | ---: | ---: |
| Interrogate 1.7.0 | 45.0% | 83.4% |
| docstr-coverage 2.3.2 | 45.2% | 83.5% |
| Function definitions (AST) | 38.01% | 80.30% |

These package-wide measurements are distinct from CodeRabbit's changed-function coverage.

## Validation and scope

Main through `373917e`, including #95 and prerequisite #96, is merged into this branch. The PR diff now excludes the predecessor's refactoring.

- 70 targeted tests pass after the review fixes, including regressions for empty collections/audio, missing chunk reference keys, paired corpus routing from file-list inputs, and ASR metadata discovery.
- Formatting, blocking Flake8 checks, and all three coverage gates pass locally.
- The initial documentation-only change also passed 118 focused tests (one optional real-model test skipped) and an executable-AST comparison. The review fixes above intentionally change input validation and reference routing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive docstring coverage checks to CI, with local instructions for contributors.
  * Improved scoring validation for chunked inputs and corpus references.
  * Added clearer handling for empty metric inputs and references.

* **Bug Fixes**
  * Corrected ASR matching results to be reported as structured output.
  * Improved Qwen metric response handling and standardized postprocessing behavior.
  * Fixed baseline selection and validation for audio distribution metrics.

* **Documentation**
  * Expanded documentation across metrics, scoring tools, contributor guidance, and CI checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->